### PR TITLE
MGDSTRM-919: Added missing metrics to GetPrometheusRemoteWriteConfig

### DIFF
--- a/controllers/model/prometheus_resources.go
+++ b/controllers/model/prometheus_resources.go
@@ -176,7 +176,7 @@ func GetPrometheusRemoteWriteConfig(cr *v1.Observability, tokenSecret string) []
 			WriteRelabelConfigs: []prometheusv1.RelabelConfig{
 				{
 					SourceLabels: []string{"__name__"},
-					Regex:        "(kafka_controller.*$|console_url$|csv_succeeded$|csv_abnormal$|cluster_version$|ALERTS$|strimzi_.*$|subscription_sync_total)",
+					Regex:        "(kafka_controller.*$|console_url$|csv_succeeded$|csv_abnormal$|cluster_version$|ALERTS$|strimzi_.*$|subscription_sync_total|node.*$|kube.*$|container.*$)",
 					Action:       "keep",
 				},
 			},


### PR DESCRIPTION
Added missing metrics to WriteRelabelConfigs to be send to Observatorium per https://issues.redhat.com/browse/MGDSTRM-919. Definition has been changed to :`(kafka_controller.*$|console_url$|csv_succeeded$|csv_abnormal$|cluster_version$|ALERTS$|strimzi_.*$|subscription_sync_total|node.*$|kube.*$|container.*$)`

Built image and tested in lab OCP server , metrics are being sent now from this particular environment 