### PR TITLE
MGDSTRM-947: active controller count query for multiple kafka clusters

### DIFF
--- a/controllers/reconcilers/prometheus_rules/prometheus_rules_reconciler.go
+++ b/controllers/reconcilers/prometheus_rules/prometheus_rules_reconciler.go
@@ -435,7 +435,7 @@ func (r *Reconciler) reconcileRule(ctx context.Context, cr *v1.Observability) (v
 								"summary":     "Kafka abnormal controller state",
 								"description": "There are {{ $value }} active controllers in the cluster",
 							},
-							Expr: intstr.Parse("sum(kafka_controller_kafkacontroller_active_controller_count) != 1"),
+							Expr: intstr.Parse("sum(kafka_controller_kafkacontroller_active_controller_count) by (strimzi_io_name) != 1"),
 							Labels: map[string]string{
 								"severity": "warning",
 							},


### PR DESCRIPTION
Altering the ActiveControllerCount query to account for multiple Kafka clusters on an k8s cluster. Currently, the alert gives a false-positive as there is (correctly) one active controller per kafka cluster & they're being summed together. See [JIRA](https://issues.redhat.com/browse/MGDSTRM-947) for further info.
