### PR TITLE
Add user-facing metrics to remote write definition for Observatorium

### DIFF
--- a/controllers/model/prometheus_resources.go
+++ b/controllers/model/prometheus_resources.go
@@ -181,7 +181,7 @@ func GetPrometheusRemoteWriteConfig(cr *v1.Observability, tokenSecret string) []
 			WriteRelabelConfigs: []prometheusv1.RelabelConfig{
 				{
 					SourceLabels: []string{"__name__"},
-					Regex:        "(kafka_controller.*$|console_url$|csv_succeeded$|csv_abnormal$|cluster_version$|ALERTS$|strimzi_.*$|subscription_sync_total|node.*$|kube.*$|container.*$)",
+					Regex:        "(kafka_controller.*$|console_url$|csv_succeeded$|csv_abnormal$|cluster_version$|ALERTS$|strimzi_.*$|subscription_sync_total|node.*$|kube.*$|container.*$|kafka_server_brokertopicmetrics_bytes.*$|kubelet_volume_stats_available_bytes$|kafka_log_log_size$)",
 					Action:       "keep",
 				},
 			},


### PR DESCRIPTION
Adds additional sets of metrics to be forwarded to Observatorium to be used for customer monitoring view as part of [JIRA ticker MGDSTRM-1010](https://issues.redhat.com/browse/MGDSTRM-1010) . Metrics will be pulled by Control Plane. This is an initial set and potentially will be expanded based on UX team requirements 