### PR TITLE
auto-create operand if not present on operator start-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,9 @@
 # Observability Operator (early WIP)
 
 ### Running Operator:
-- operator largely intended to be ran locally via `make` for now:
-  - if changes are made, first do:
+  - if image changes required, first do:
     - `make generate`
     - `make manifests`
   - `make install`
   - `make run ENABLE_WEBHOOKS=false`
   - see [operator-sdk documentation](https://sdk.operatorframework.io/docs/building-operators/golang/tutorial/) for further info
-
-**NOTE**: when running the operator, it will:
-- create its own operand (Observability CR) on start-up
-  - reference `main.go:L82-96`
-- create any resources found in the `config/observability` directory
-  - some value substitutions are made, see `observability_controller.go:L143-145`
-- delete the CR on `SIGINT/KILL` which will garbage-collect all owned resources it creates 
-  - reference `main.go:L107-114`

--- a/main.go
+++ b/main.go
@@ -103,7 +103,6 @@ func main() {
 
 	if err = observabilityReconciler.InitializeOperand(mgr); err != nil {
 		setupLog.Error(err, "unable to create operand", "controller", "Observability")
-		os.Exit(1)
 	}
 
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {


### PR DESCRIPTION
We want to instantiate our operand for pre-warming prior to agent/config fetch, but it's also possible that our operator could restart or be rolled after configuration has been applied that we'd want to maintain. Alternatively, we could rebuild the operand and config fetch at every operator start, but for now, I've chosen the preservation path. 

At start-up, operator will check for an existing target operand and instantiate if not found. Will also warn if other rogue instances were found in the process(more likely to happen in local/dev instances, but still useful info IMO!)