### PR TITLE
Add kafka_server_brokertopicmetrics_messages_in_total to remote write config

### DIFF
--- a/controllers/model/prometheus_resources.go
+++ b/controllers/model/prometheus_resources.go
@@ -181,7 +181,7 @@ func GetPrometheusRemoteWriteConfig(cr *v1.Observability, tokenSecret string) []
 			WriteRelabelConfigs: []prometheusv1.RelabelConfig{
 				{
 					SourceLabels: []string{"__name__"},
-					Regex:        "(kafka_controller.*$|console_url$|csv_succeeded$|csv_abnormal$|cluster_version$|ALERTS$|strimzi_.*$|subscription_sync_total|node.*$|kube.*$|container.*$|kafka_server_brokertopicmetrics_bytes.*$|kubelet_volume_stats_available_bytes$|kafka_log_log_size$)",
+					Regex:        "(kafka_controller.*$|console_url$|csv_succeeded$|csv_abnormal$|cluster_version$|ALERTS$|strimzi_.*$|subscription_sync_total|node.*$|kube.*$|container.*$|kafka_server_brokertopicmetrics_bytes.*$|kafka_server_brokertopicmetrics_messages_in_total$|kubelet_volume_stats_available_bytes$|kafka_log_log_size$)",
 					Action:       "keep",
 				},
 			},


### PR DESCRIPTION
Additional metric kafka_server_brokertopicmetrics_messages_in_total  needed for user facing monitoring as part of MGDSTRM-1010