### PR TITLE
MGDSTRM-1064 Remove user specific rules

### DIFF
--- a/controllers/reconcilers/prometheus_rules/prometheus_rules_reconciler.go
+++ b/controllers/reconcilers/prometheus_rules/prometheus_rules_reconciler.go
@@ -2,6 +2,7 @@ package prometheus_rules
 
 import (
 	"context"
+
 	prometheusv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/go-logr/logr"
 	v1 "github.com/jeremyary/observability-operator/api/v1"
@@ -623,31 +624,6 @@ func (r *Reconciler) reconcileRule(ctx context.Context, cr *v1.Observability) (v
 								"description": "Topic  {{ $labels.topic }} has {{ $value }} under-replicated partition {{ $labels.partition }}",
 							},
 							Expr: intstr.Parse("kafka_topic_partition_under_replicated_partition > 0"),
-							Labels: map[string]string{
-								"severity": "warning",
-							},
-						},
-						{
-							Alert: "TooLargeConsumerGroupLag",
-							For:   "10s",
-							Annotations: map[string]string{
-								"summary": "Consumer group lag is too big",
-								"description": "Consumer group {{ $labels.consumergroup}} lag is too big ({{ $value }}) on topic " +
-									"{{ $labels.topic }}/partition {{ $labels.partition }}",
-							},
-							Expr: intstr.Parse("kafka_consumergroup_lag > 1000"),
-							Labels: map[string]string{
-								"severity": "warning",
-							},
-						},
-						{
-							Alert: "NoMessageForTooLong",
-							For:   "10s",
-							Annotations: map[string]string{
-								"summary":     "No message for 10 minutes",
-								"description": "There is no messages in topic {{ $labels.topic}}/partition {{ $labels.partition }} for 10 minutes",
-							},
-							Expr: intstr.Parse("changes(kafka_topic_partition_current_offset{topic!=\"__consumer_offsets\"}[10m]) == 0"),
 							Labels: map[string]string{
 								"severity": "warning",
 							},


### PR DESCRIPTION
https://issues.redhat.com/browse/MGDSTRM-1064

These 2 rules are very specific to how a user would use the system and may actually be false positives from a managed kafka point of view.
Let's remove them to avoid unnecessary toil and focus on other ways of detecting service problems.

Examples of when these are false positives:
- NoMessageForTooLong - the user's application is offline or in a quiet period where no messages are actually being sent. This isn't necessarily a service management problem.
- TooLargeConsumerGroupLag - a user's application that consumes messages may be offline or unable to consume fast enough compared to the produce rate. Again, this isn't necessarily a service management problem.