### PR TITLE
Addition of critical alertmanager receiver

### DIFF
--- a/controllers/model/alertmanager_resources.go
+++ b/controllers/model/alertmanager_resources.go
@@ -110,13 +110,17 @@ route:
         alertname: DeadMansSwitch
       repeat_interval: 5m
       receiver: deadmansswitch
+    - match:
+        severity: critical
+      receiver: critical
 receivers:
   - name: default
-    pagerduty_configs:
-      - service_key: {{ .PagerDutyServiceKey }}
   - name: deadmansswitch
     webhook_configs:
       - url: {{ .DeadMansSnitchURL }}
+  - name: critical
+    pagerduty_configs:
+      - service_key: {{ .PagerDutyServiceKey }}
 `
 	template := t.Must(t.New("template").Parse(config))
 	var buffer bytes.Buffer


### PR DESCRIPTION
[MGDSTRM-1042](https://issues.redhat.com/browse/MGDSTRM-1042)

- Only critical alerts should be sent to PagerDuty
- Added a new `critical` route and receiver