### PR TITLE
Addition of critical alertmanager receiver (v1 branch)

### DIFF
--- a/controllers/model/alertmanager_resources.go
+++ b/controllers/model/alertmanager_resources.go
@@ -110,13 +110,17 @@ route:
         alertname: DeadMansSwitch
       repeat_interval: 5m
       receiver: deadmansswitch
+    - match:
+        severity: critical
+      receiver: critical
 receivers:
   - name: default
-    pagerduty_configs:
-      - service_key: {{ .PagerDutyServiceKey }}
   - name: deadmansswitch
     webhook_configs:
       - url: {{ .DeadMansSnitchURL }}
+  - name: critical
+    pagerduty_configs:
+      - service_key: {{ .PagerDutyServiceKey }}
 `
 	template := t.Must(t.New("template").Parse(config))
 	var buffer bytes.Buffer


### PR DESCRIPTION
Same as https://github.com/bf2fc6cc711aee1a0c2a/observability-operator/pull/17 but for the `v1` branch.