### PR TITLE
add missing parens on dexConfig

### DIFF
--- a/api/v1/index.go
+++ b/api/v1/index.go
@@ -20,7 +20,7 @@ type ObservatoriumIndex struct {
 	Gateway   string                `json:"gateway"`
 	Tenant    string                `json:"tenant"`
 	AuthType  ObservabilityAuthType `json:"authType"`
-	DexConfig *DexConfig            `json:dexConfig,omitempty`
+	DexConfig *DexConfig            `json:"dexConfig,omitempty"`
 }
 
 type RemoteWriteIndex struct {


### PR DESCRIPTION
`make run` complains about field tag, fails to start:
```
api/v1/index.go:23:2: struct field tag `json:dexConfig,omitempty` not compatible with reflect.StructTag.Get: bad syntax for struct tag value
```