### PR TITLE
fix: make sure resources are not overwritten by their on-cluster inst…

### DIFF
--- a/controllers/reconcilers/configuration/grafana_dashboards.go
+++ b/controllers/reconcilers/configuration/grafana_dashboards.go
@@ -127,10 +127,15 @@ func (r *Reconciler) createRequestedDashboards(cr *v1.Observability, ctx context
 
 	// Sync requested dashboards
 	for _, dashboard := range requestedDashboards {
+
+		requestedSpec := dashboard.Spec
+		requestedLabels := dashboard.Labels
+
 		_, err := controllerutil.CreateOrUpdate(ctx, r.client, dashboard, func() error {
-			dashboard.Labels = map[string]string{
+			dashboard.Spec = requestedSpec
+			dashboard.Labels = MergeLabels(map[string]string{
 				"managed-by": "observability-operator",
-			}
+			}, requestedLabels)
 			return nil
 		})
 		if err != nil {

--- a/controllers/reconcilers/configuration/pod_monitors.go
+++ b/controllers/reconcilers/configuration/pod_monitors.go
@@ -92,10 +92,14 @@ func (r *Reconciler) createRequestedPodMonitors(cr *v1.Observability, ctx contex
 			return err
 		}
 
+		requestedLabels := monitor.Labels
+		requestedSpec := monitor.Spec
+
 		_, err = controllerutil.CreateOrUpdate(ctx, r.client, monitor, func() error {
+			monitor.Spec = requestedSpec
 			monitor.Labels = MergeLabels(map[string]string{
 				"managed-by": "observability-operator",
-			}, monitor.Labels)
+			}, requestedLabels)
 			return nil
 		})
 		if err != nil {

--- a/controllers/reconcilers/configuration/prometheus_rules.go
+++ b/controllers/reconcilers/configuration/prometheus_rules.go
@@ -89,11 +89,15 @@ func (r *Reconciler) createRequestedRules(cr *v1.Observability, ctx context.Cont
 			return err
 		}
 
+		requestedSpec := parsedRule.Spec
+		requestedLabels := parsedRule.Labels
+
 		_, err = controllerutil.CreateOrUpdate(ctx, r.client, parsedRule, func() error {
 			// Add managed label to Rule CR
-			parsedRule.Labels = map[string]string{
+			parsedRule.Spec = requestedSpec
+			parsedRule.Labels = MergeLabels(map[string]string{
 				"managed-by": "observability-operator",
-			}
+			}, requestedLabels)
 			// Inject managed labels for each rule
 			injectIdLabel(parsedRule, rule.Id)
 			return nil


### PR DESCRIPTION
Make sure spec and labels of resources defined in the repo can actually be applied to the cluster. The problem is that the `CreateOrUpdate` function that we are using performs a `Get` on the parsed resource which overwrites all the changes from the repo with the version on cluster. 

Fix: temporary store the labels and spec and reapply them after the Get.