### PR TITLE
adding logging

### DIFF
--- a/controllers/reconcilers/configuration/grafana_dashboards.go
+++ b/controllers/reconcilers/configuration/grafana_dashboards.go
@@ -204,6 +204,10 @@ func (r *Reconciler) fetchDashboard(path string, token string) (SourceType, []by
 		return SourceTypeUnknown, nil, err
 	}
 
+	if token == "" {
+		return SourceTypeUnknown, nil, fmt.Errorf("repository ConfigMap missing required AccessToken")
+	}
+
 	req, err := http.NewRequest(http.MethodGet, url.String(), nil)
 	if err != nil {
 		return SourceTypeUnknown, nil, err


### PR DESCRIPTION
* started the operator, operator adds CR and does a new installation:
```
jary@pop-os:~/redhat/git/observability-operator$ make run ENABLE_WEBHOOKS=false WATCH_NAMESPACE=kafka_observability
/home/jary/redhat/bin/controller-gen object:headerFile="hack/boilerplate.go.txt" paths="./..."
go fmt ./...
go vet ./...
/home/jary/redhat/bin/controller-gen "crd:trivialVersions=true" rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
go run ./main.go
I0223 16:25:29.599605 1335375 request.go:645] Throttling request took 1.027209989s, request: GET:https://api.crc.testing:6443/apis/coordination.k8s.io/v1beta1?timeout=32s
2021-02-23T16:25:30.953-0600	INFO	controller-runtime.metrics	metrics server is starting to listen	{"addr": ":8080"}
2021-02-23T16:25:30.953-0600	INFO	controllers.Observability	determining if operand instantiation required
2021-02-23T16:25:30.959-0600	INFO	controllers.Observability	Operand with target name/namespace detected, skipping auto-create
2021-02-23T16:25:30.959-0600	INFO	controller-runtime.manager	starting metrics server	{"path": "/metrics"}
2021-02-23T16:25:30.959-0600	INFO	controller	Starting EventSource	{"reconcilerGroup": "observability.redhat.com", "reconcilerKind": "Observability", "controller": "observability", "source": "kind source: /, Kind="}
2021-02-23T16:25:31.059-0600	INFO	controller	Starting Controller	{"reconcilerGroup": "observability.redhat.com", "reconcilerKind": "Observability", "controller": "observability"}
2021-02-23T16:25:31.059-0600	INFO	controller	Starting workers	{"reconcilerGroup": "observability.redhat.com", "reconcilerKind": "Observability", "controller": "observability", "worker count": 1}
2021-02-23T16:25:33.200-0600	INFO	controllers.Observability	token resync window elapsed, proceeding with re-fetch	{"observability": "observability-stack", "configured resync period": "1h"}
2021-02-23T16:25:33.200-0600	INFO	controllers.Observability	configurations found, resync initiated	{"observability": "observability-stack", "configuration count": 1}
2021-02-23T16:25:33.406-0600	INFO	controllers.Observability	observatorium token missing or expired, refreshing	{"observability": "observability-stack"}
2021-02-23T16:25:34.251-0600	INFO	controllers.Observability	new observatorium token expiry	{"observability": "observability-stack", "epoch": 1645655133}
2021-02-23T16:25:36.483-0600	INFO	controllers.Observability	stack installation complete	{"observability": "kafka-observability/observability-stack"}
```

* Now I delete the CR, trigger a stack cleanup:
```
2021-02-23T16:07:09.853-0600	INFO	controllers.Observability	stack cleanup in progress	{"observability": "kafka-observability/observability-stack", "working stage": "GrafanaConfiguration"}
2021-02-23T16:07:11.079-0600	INFO	controllers.Observability	stack cleanup in progress	{"observability": "kafka-observability/observability-stack", "working stage": "CsvRemoval"}
2021-02-23T16:07:11.181-0600	INFO	controllers.Observability	stack cleanup in progress	{"observability": "kafka-observability/observability-stack", "working stage": "CsvRemoval"}
2021-02-23T16:07:14.932-0600	INFO	controllers.Observability	cleanup stages complete, removing finalizer	{"observability": "kafka-observability/observability-stack"}
2021-02-23T16:07:14.939-0600	DEBUG	controller	Successfully Reconciled	{"reconcilerGroup": "observability.redhat.com", "reconcilerKind": "Observability", "controller": "observability", "name": "observability-stack", "namespace": "kafka-observability"}
2021-02-23T16:07:14.939-0600	INFO	controllers.Observability	Observability CR not found, has been deleted	{"observability": "kafka-observability/observability-stack"}
2021-02-23T16:07:14.939-0600	DEBUG	controller	Successfully Reconciled	{"reconcilerGroup": "observability.redhat.com", "reconcilerKind": "Observability", "controller": "observability", "name": "observability-stack", "namespace": "kafka-observability"}
2021-02-23T16:08:16.590-0600	DEBUG	controller	Successfully Reconciled	{"reconcilerGroup": "observability.redhat.com", "reconcilerKind": "Observability", "controller": "observability", "name": "observability-stack", "namespace": "kafka-observability"}
```

* Added a new CR to trigger a fresh install:
```
2021-02-23T16:08:16.612-0600	INFO	controllers.Observability	stack install in progress	{"observability": "kafka-observability/observability-stack", "working stage": "Prometheus"}
2021-02-23T16:08:16.618-0600	INFO	controllers.Observability	stack install in progress	{"observability": "kafka-observability/observability-stack", "working stage": "Prometheus"}
2021-02-23T16:08:26.769-0600	INFO	controllers.Observability	stack install in progress	{"observability": "kafka-observability/observability-stack", "working stage": "PrometheusConfiguration"}
2021-02-23T16:08:26.802-0600	INFO	controllers.Observability	stack install in progress	{"observability": "kafka-observability/observability-stack", "working stage": "PrometheusConfiguration"}
2021-02-23T16:08:36.965-0600	INFO	controllers.Observability	stack install in progress	{"observability": "kafka-observability/observability-stack", "working stage": "Grafana"}
2021-02-23T16:08:36.991-0600	INFO	controllers.Observability	stack install in progress	{"observability": "kafka-observability/observability-stack", "working stage": "Grafana"}
2021-02-23T16:08:47.102-0600	INFO	controllers.Observability	stack install in progress	{"observability": "kafka-observability/observability-stack", "working stage": "AlertmanagerInstallation"}
2021-02-23T16:08:47.129-0600	INFO	controllers.Observability	stack install in progress	{"observability": "kafka-observability/observability-stack", "working stage": "AlertmanagerInstallation"}
2021-02-23T16:08:57.157-0600	INFO	controllers.Observability	token resync window elapsed, proceeding with re-fetch	{"observability": "observability-stack", "configured resync period": "5m"}
2021-02-23T16:08:57.157-0600	INFO	controllers.Observability	configurations found, resync initiated	{"observability": "observability-stack", "configuration count": 1}
2021-02-23T16:08:57.353-0600	INFO	controllers.Observability	observatorium token missing or expired, refreshing	{"observability": "observability-stack"}
2021-02-23T16:08:57.812-0600	INFO	controllers.Observability	new observatorium token expiry	{"observability": "observability-stack", "epoch": 1645654136}
2021-02-23T16:08:59.495-0600	INFO	controllers.Observability	stack installation complete	{"observability": "kafka-observability/observability-stack"}
```

* after the resync period I configured to 5m elapsed:
```
2021-02-23T16:14:00.739-0600	INFO	controllers.Observability	token resync window elapsed, proceeding with re-fetch	{"observability": "observability-stack", "configured resync period": "5m"}
2021-02-23T16:14:00.740-0600	INFO	controllers.Observability	configurations found, resync initiated	{"observability": "observability-stack", "configuration count": 1}
```

* removed the access token within the ConfigMap to simulate a developer forgetting to supply the secret or a failed Vault fetch:
```
2021-02-23T16:23:46.801-0600	ERROR	controllers.Observability	reconciler error in stage configuration	{"observability": "kafka-observability/observability-stack", "error": "repository ConfigMap missing required AccessToken"}
github.com/go-logr/zapr.(*zapLogger).Error
	/home/jary/redhat/pkg/mod/github.com/go-logr/zapr@v0.2.0/zapr.go:132
github.com/bf2fc6cc711aee1a0c2a/observability-operator/controllers.(*ObservabilityReconciler).Reconcile
	/home/jary/redhat/git/observability-operator/controllers/observability_controller.go:114
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
	/home/jary/redhat/pkg/mod/sigs.k8s.io/controller-runtime@v0.6.2/pkg/internal/controller/controller.go:235
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
	/home/jary/redhat/pkg/mod/sigs.k8s.io/controller-runtime@v0.6.2/pkg/internal/controller/controller.go:209
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker
	/home/jary/redhat/pkg/mod/sigs.k8s.io/controller-runtime@v0.6.2/pkg/internal/controller/controller.go:188
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1
	/home/jary/redhat/pkg/mod/k8s.io/apimachinery@v0.19.2/pkg/util/wait/wait.go:155
k8s.io/apimachinery/pkg/util/wait.BackoffUntil
	/home/jary/redhat/pkg/mod/k8s.io/apimachinery@v0.19.2/pkg/util/wait/wait.go:156
k8s.io/apimachinery/pkg/util/wait.JitterUntil
	/home/jary/redhat/pkg/mod/k8s.io/apimachinery@v0.19.2/pkg/util/wait/wait.go:133
k8s.io/apimachinery/pkg/util/wait.Until
	/home/jary/redhat/pkg/mod/k8s.io/apimachinery@v0.19.2/pkg/util/wait/wait.go:90
2021-02-23T16:23:46.801-0600	INFO	controllers.Observability	stack install in progress	{"observability": "kafka-observability/observability-stack", "working stage": "configuration"}
```