### PR TITLE
access token verbiage update

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ review the content of each!
 * External config repo ConfigMap:
     * The Observability stack requires a Personal Access Token to read externalized configuration from within the bf2 organization. For development cycles, you will need to generate a personal token for your own GitHub user (with bf2 access) and place the value in the ConfigMap. 
     * To generate a new token:
-        * Follow the steps [found here](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token), making sure to check **ONLY** the `repo` box at the top of the scopes/permissions list (which will check the 3 subcategory boxes beneath it).
+        * Follow the steps [found here](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token), making sure to check **ONLY** the `repo` box at the top of the scopes/permissions list (which will check each of the subcategory boxes beneath it).
         * Copy the value of your Personal Access Token to a secure private location. Once you leave the page, you cannot access the value again & you will be forced to reset the token to receive a new value should you lose the original.
         * Take care not to push your PAT to any repository as if you do, GitHub will automatically revoke your token as soon as you push and you'll need to follow this process again to generate a new token.
     * Apply the ConfigMap with token value substituted in:


### PR DESCRIPTION
I was incorrect on the number of subcategory boxes that are selected during the PAT process when checking `repo`.