### PR TITLE
fix: support prometheusrules without any labels

### DIFF
--- a/controllers/reconcilers/configuration/configuration_reconciler.go
+++ b/controllers/reconcilers/configuration/configuration_reconciler.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	v1 "github.com/bf2fc6cc711aee1a0c2a/observability-operator/api/v1"
-	"github.com/bf2fc6cc711aee1a0c2a/observability-operator/controllers/model"
 	"github.com/bf2fc6cc711aee1a0c2a/observability-operator/controllers/reconcilers"
 	token2 "github.com/bf2fc6cc711aee1a0c2a/observability-operator/controllers/reconcilers/token"
 	"github.com/go-logr/logr"
@@ -170,21 +169,6 @@ func (r *Reconciler) stampConfigSource(ctx context.Context, index *v1.Repository
 	}
 
 	return nil
-}
-
-func (r *Reconciler) getTokenLifetimeStorage(ctx context.Context, cr *v1.Observability) (*v12.ConfigMap, error) {
-	storage := model.GetPrometheusAuthTokenLifetimes(cr)
-	selector := client.ObjectKey{
-		Namespace: cr.Namespace,
-		Name:      storage.Name,
-	}
-
-	err := r.client.Get(ctx, selector, storage)
-	if err != nil {
-		return nil, err
-	}
-
-	return storage, err
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, cr *v1.Observability, s *v1.ObservabilityStatus) (v1.ObservabilityStageStatus, error) {

--- a/controllers/reconcilers/configuration/prometheus_rules.go
+++ b/controllers/reconcilers/configuration/prometheus_rules.go
@@ -114,6 +114,9 @@ func (r *Reconciler) createRequestedRules(cr *v1.Observability, ctx context.Cont
 func injectIdLabel(rule *v12.PrometheusRule, id string) {
 	for i := 0; i < len(rule.Spec.Groups); i++ {
 		for j := 0; j < len(rule.Spec.Groups[i].Rules); j++ {
+			if rule.Spec.Groups[i].Rules[j].Labels == nil {
+				rule.Spec.Groups[i].Rules[j].Labels = make(map[string]string)
+			}
 			rule.Spec.Groups[i].Rules[j].Labels[PrometheusRuleIdentifierKey] = id
 		}
 	}


### PR DESCRIPTION
The operator is crashing if a prometheus rule has no labels. This is because we don't nil check before assigning a new label.