### PR TITLE
fix: increase memory limits to prevent oomkilled

### DIFF
--- a/bundle/manifests/observability-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/observability-operator.clusterserviceversion.yaml
@@ -302,10 +302,10 @@ spec:
                 resources:
                   limits:
                     cpu: 100m
-                    memory: 30Mi
+                    memory: 500Mi
                   requests:
                     cpu: 100m
-                    memory: 20Mi
+                    memory: 50Mi
               terminationGracePeriodSeconds: 10
       permissions:
       - rules:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -32,8 +32,8 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 30Mi
+            memory: 500Mi
           requests:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
30Mb is not enough to run the operator

ping @miguelsorianod 