### PR TITLE
feat: update token refresher image tag to e85bec4

### DIFF
--- a/controllers/reconcilers/configuration/token_refresher.go
+++ b/controllers/reconcilers/configuration/token_refresher.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	TokenRefresherImageTag = "latest"
+	TokenRefresherImageTag = "e85bec4"
 )
 
 // Return a set of credentials and configuration for either logs or metrics


### PR DESCRIPTION
Update image tag of token refresher image to use `e85bec4`. https://quay.io/repository/rhoas/mk-token-refresher?tab=tags

Related JIRA: [MGDSTRM-4987](https://issues.redhat.com/browse/MGDSTRM-4987) and [MGDSTRM-4546](https://issues.redhat.com/browse/MGDSTRM-4546)