### PR TITLE
Add and override for Prometheus and Alertmanager routes

### DIFF
--- a/api/v1/observability_types.go
+++ b/api/v1/observability_types.go
@@ -76,6 +76,8 @@ type SelfContained struct {
 	ProbeNamespaceSelector          *metav1.LabelSelector `json:"probeNamespaceSelector,omitempty"`
 	GrafanaDashboardLabelSelector   *metav1.LabelSelector `json:"grafanaDashboardLabelSelector,omitempty"`
 	AlertManagerConfigSecret        string                `json:"alertManagerConfigSecret,omitempty"`
+	AlertManagerRoute               string                `json:"alertManagerRoute,omitempty"`
+	PrometheusRoute                 string                `json:"prometheusRoute,omitempty"`
 }
 
 // ObservabilitySpec defines the desired state of Observability

--- a/config/crd/bases/observability.redhat.com_observabilities.yaml
+++ b/config/crd/bases/observability.redhat.com_observabilities.yaml
@@ -664,6 +664,8 @@ spec:
               properties:
                 alertManagerConfigSecret:
                   type: string
+                alertManagerRoute:
+                  type: string
                 disableBlackboxExporter:
                   type: boolean
                 disableDeadmansSnitch:
@@ -725,6 +727,8 @@ spec:
                         are ANDed.
                       type: object
                   type: object
+                grafanaRoute:
+                  type: string
                 podMonitorLabelSelector:
                   description: A label selector is a label query over a set of resources.
                     The result of matchLabels and matchExpressions are ANDed. An empty
@@ -913,6 +917,8 @@ spec:
                         are ANDed.
                       type: object
                   type: object
+                prometheusRoute:
+                  type: string
                 ruleLabelSelector:
                   description: A label selector is a label query over a set of resources.
                     The result of matchLabels and matchExpressions are ANDed. An empty

--- a/controllers/model/alertmanager_resources.go
+++ b/controllers/model/alertmanager_resources.go
@@ -29,6 +29,14 @@ func GetAlertmanagerTLSSecret(cr *v1.Observability) *v13.Secret {
 }
 
 func GetAlertmanagerRoute(cr *v1.Observability) *routev1.Route {
+	if cr.Spec.SelfContained != nil && cr.Spec.SelfContained.AlertManagerRoute != "" {
+		return &routev1.Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      cr.Spec.SelfContained.AlertManagerRoute,
+				Namespace: cr.Namespace,
+			},
+		}
+	}
 	return &routev1.Route{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "kafka-alertmanager",

--- a/controllers/model/prometheus_resources.go
+++ b/controllers/model/prometheus_resources.go
@@ -115,6 +115,14 @@ func GetPrometheusClusterRoleBinding() *v14.ClusterRoleBinding {
 }
 
 func GetPrometheusRoute(cr *v1.Observability) *routev1.Route {
+	if cr.Spec.SelfContained != nil && cr.Spec.SelfContained.PrometheusRoute != "" {
+		return &routev1.Route{
+			ObjectMeta: v12.ObjectMeta{
+				Name:      cr.Spec.SelfContained.PrometheusRoute,
+				Namespace: cr.Namespace,
+			},
+		}
+	}
 	return &routev1.Route{
 		ObjectMeta: v12.ObjectMeta{
 			Name:      "kafka-prometheus",


### PR DESCRIPTION
# What
update the observability Spec.selfcontained to have a override for the default route names for prometheus and Alertmanger

# Verify 
- deploy the operator locally
- Create a Observability cr with the following spec
```yaml
spec:
  configurationSelector:
    matchLabels:
      monitoring-key: middleware
  resyncPeriod: 1h
  selfContained:
    disableDeadmansSnitch: true
    disablePagerDuty: true
    disableRepoSync: true
    prometheusRoute: prometheus-route
    alertManagerRoute: alertmanager-route
```
- Confirm when deployed that the Route for prometheus and alertmanager are pointing at `prometheus-route`
    and `alertmanager-route`
- delete the observability CR
- create an observability CR with the following spec and see if the route name is reverted to `kafka-alertmanager` & `kafak-prometheus`
```yaml
spec:
  configurationSelector:
    matchLabels:
      monitoring-key: middleware
  resyncPeriod: 1h
  selfContained:
    disableDeadmansSnitch: true
    disablePagerDuty: true
    disableRepoSync: true
```