### PR TITLE
update all versions of oauth-proxy

### DIFF
--- a/controllers/reconcilers/configuration/alertmanager.go
+++ b/controllers/reconcilers/configuration/alertmanager.go
@@ -48,7 +48,7 @@ func (r *Reconciler) reconcileAlertmanager(ctx context.Context, cr *v1.Observabi
 		alertmanager.Spec.Containers = []v12.Container{
 			{
 				Name:  "oauth-proxy",
-				Image: "quay.io/openshift/origin-oauth-proxy:4.2",
+				Image: "quay.io/openshift/origin-oauth-proxy:4.8",
 				Args: []string{
 					"-provider=openshift",
 					"-https-address=:9091",

--- a/controllers/reconcilers/configuration/grafana.go
+++ b/controllers/reconcilers/configuration/grafana.go
@@ -39,7 +39,7 @@ func (r *Reconciler) reconcileGrafanaCr(ctx context.Context, cr *v1.Observabilit
 			Containers: []core.Container{
 				{
 					Name:  "grafana-proxy",
-					Image: "quay.io/openshift/origin-oauth-proxy:4.2",
+					Image: "quay.io/openshift/origin-oauth-proxy:4.8",
 					Args: []string{
 						"-provider=openshift",
 						"-pass-basic-auth=false",

--- a/controllers/reconcilers/configuration/prometheus.go
+++ b/controllers/reconcilers/configuration/prometheus.go
@@ -324,7 +324,7 @@ func (r *Reconciler) reconcilePrometheus(ctx context.Context, cr *v1.Observabili
 
 	sidecars = append(sidecars, kv1.Container{
 		Name:  "oauth-proxy",
-		Image: "quay.io/openshift/origin-oauth-proxy:4.2",
+		Image: "quay.io/openshift/origin-oauth-proxy:4.8",
 		Args: []string{
 			"-provider=openshift",
 			"-https-address=:9091",


### PR DESCRIPTION
This pr relates to this change comment -> https://github.com/integr8ly/integreatly-operator/pull/2070#issuecomment-931442219
oauth 4.2 doesn't work on 4.9
I've tested both 4.9 and 4.8 on a 4.9 cluster
I think it's safer to go with 4.8 as I haven't tested 4.9 on a 4.8 cluster.