### PR TITLE
add target for building index image via opm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,6 +145,10 @@ bundle-push:
 index-build:
 	docker build -t $(INDEX_IMG) -f opm.Dockerfile .
 
+.PHONY: opm-build
+opm-build:
+	@bash build_index.sh
+
 .PHONY: index-push
 index-push:
 	docker push $(INDEX_IMG)

--- a/bundle_history.txt
+++ b/bundle_history.txt
@@ -5,3 +5,5 @@ quay.io/integreatly/observability-operator-bundle:v3.0.1
 quay.io/bf2fc6cc711aee1a0c2a82e312df7f2e6b37baa12bd9b1f2fd752e260d93a6f8144ac730947f25caa2bfe6ad0f410da360940ee6d28d6c1688d3822c4055650e/observability-operator-bundle:v3.0.2
 quay.io/bf2fc6cc711aee1a0c2a82e312df7f2e6b37baa12bd9b1f2fd752e260d93a6f8144ac730947f25caa2bfe6ad0f410da360940ee6d28d6c1688d3822c4055650e/observability-operator-bundle:v3.0.3
 quay.io/rhoas/observability-operator-bundle:v3.0.4
+quay.io/rhoas/observability-operator-bundle:v3.0.5
+quay.io/rhoas/observability-operator-bundle:v3.0.6


### PR DESCRIPTION
add target for building index image via opm. This also downloads the opm binary if not installed.