### PR TITLE
Change override to return empty object instead of nil.

### DIFF
--- a/controllers/model/prometheus_resources.go
+++ b/controllers/model/prometheus_resources.go
@@ -270,7 +270,7 @@ func GetPrometheusPodMonitorLabelSelectors(cr *v1.Observability, indexes []v1.Re
 	}
 
 	if cr.OverrideSelectors() && cr.Spec.SelfContained.PodMonitorLabelSelector == nil {
-		return nil
+		return &v12.LabelSelector{}
 	}
 
 	prometheusConfig := getPrometheusRepositoryIndexConfig(indexes)
@@ -289,7 +289,7 @@ func GetPrometheusServiceMonitorLabelSelectors(cr *v1.Observability, indexes []v
 	}
 
 	if cr.OverrideSelectors() && cr.Spec.SelfContained.ServiceMonitorLabelSelector == nil {
-		return nil
+		return &v12.LabelSelector{}
 	}
 
 	prometheusConfig := getPrometheusRepositoryIndexConfig(indexes)
@@ -308,7 +308,7 @@ func GetPrometheusRuleLabelSelectors(cr *v1.Observability, indexes []v1.Reposito
 	}
 
 	if cr.OverrideSelectors() && cr.Spec.SelfContained.RuleLabelSelector == nil {
-		return nil
+		return &v12.LabelSelector{}
 	}
 
 	prometheusConfig := getPrometheusRepositoryIndexConfig(indexes)
@@ -327,7 +327,7 @@ func GetProbeLabelSelectors(cr *v1.Observability, indexes []v1.RepositoryIndex) 
 	}
 
 	if cr.OverrideSelectors() && cr.Spec.SelfContained.ProbeLabelSelector == nil {
-		return nil
+		return &v12.LabelSelector{}
 	}
 
 	prometheusConfig := getPrometheusRepositoryIndexConfig(indexes)
@@ -348,7 +348,7 @@ func GetPrometheusPodMonitorNamespaceSelectors(cr *v1.Observability, indexes []v
 	}
 
 	if cr.OverrideSelectors() && cr.Spec.SelfContained.PodMonitorNamespaceSelector == nil {
-		return nil
+		return &v12.LabelSelector{}
 	}
 
 	prometheusConfig := getPrometheusRepositoryIndexConfig(indexes)
@@ -364,7 +364,7 @@ func GetPrometheusServiceMonitorNamespaceSelectors(cr *v1.Observability, indexes
 	}
 
 	if cr.OverrideSelectors() && cr.Spec.SelfContained.ServiceMonitorNamespaceSelector == nil {
-		return nil
+		return &v12.LabelSelector{}
 	}
 
 	prometheusConfig := getPrometheusRepositoryIndexConfig(indexes)
@@ -380,7 +380,7 @@ func GetPrometheusRuleNamespaceSelectors(cr *v1.Observability, indexes []v1.Repo
 	}
 
 	if cr.OverrideSelectors() && cr.Spec.SelfContained.RuleNamespaceSelector == nil {
-		return nil
+		return &v12.LabelSelector{}
 	}
 
 	prometheusConfig := getPrometheusRepositoryIndexConfig(indexes)
@@ -395,8 +395,8 @@ func GetProbeNamespaceSelectors(cr *v1.Observability, indexes []v1.RepositoryInd
 		return cr.Spec.SelfContained.ProbeNamespaceSelector
 	}
 
-	if cr.OverrideSelectors() && cr.Spec.SelfContained.RuleNamespaceSelector == nil {
-		return nil
+	if cr.OverrideSelectors() && cr.Spec.SelfContained.ProbeNamespaceSelector == nil {
+		return &v12.LabelSelector{}
 	}
 
 	prometheusConfig := getPrometheusRepositoryIndexConfig(indexes)


### PR DESCRIPTION
# What
A previous [PR](https://github.com/redhat-developer/observability-operator/pull/86) added support for overriding selectors so they could be set to nil. However further testing revealed that we actually need to have these selectors be set to an empty object `{}`.
 
# How
Changed logic in `prometheus_resources.go` to return a blank LabelSelector rather than nil when the spec.selfContained.overrideSelectors is true but the selector is blank.

# Verify
* Install the Observability Operator locally
* Create an observability CR with the following spec
```yaml
spec:
  configurationSelector:
    matchLabels:
      monitoring-key: middleware
  resyncPeriod: 1h
  selfContained:
    overrideSelectors: true
    disableDeadmansSnitch: true
    disablePagerDuty: true
    disableRepoSync: true
    serviceMonitorNamespaceSelector:
      matchExpressions:
        - key: monitoring-key
          operator: In
          values:
            - middleware
```
* Confirm that when the Prometheus CR is created it has the following content
```yaml
  serviceMonitorNamespaceSelector:
    matchExpressions:
      - key: monitoring-key
        operator: In
        values:
          - middleware
  serviceMonitorSelector: {}
  podMonitorNamespaceSelector: {}
  podMonitorSelector: {}
  probeNamespaceSelector: {}
  probeSelector: {}
  ruleNamespaceSelector:
  ruleSelector: {}
```