### PR TITLE
fix: add webhook server check

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"crypto/tls"
 	"flag"
-	"fmt"
 	"net"
 	"os"
 	"strconv"
@@ -141,15 +140,16 @@ func checkForWebhookServerReady(mgr ctrl.Manager) error {
 		InsecureSkipVerify: true, // nolint:gosec // config is used to connect to our own webhook port.
 	}
 
-	dialer := &net.Dialer{Timeout: 20 * time.Second}
+	dialer := &net.Dialer{Timeout: 30 * time.Second}
 	conn, err := tls.DialWithDialer(dialer, "tcp", net.JoinHostPort(host, strconv.Itoa(port)), config)
 	if err != nil {
-		return fmt.Errorf("webhook server is not reachable: %v", err)
+		setupLog.Error(err, "webhook server is not reachable", "webhook", "Observability")
+		return err
 	}
 	if err := conn.Close(); err != nil {
-		return fmt.Errorf("webhook server is not reachable: closing connection: %v", err)
+		setupLog.Error(err, "webhook server is not reachable: closing connection", "webhook", "Observability")
+		return err
 	}
-
 	return nil
 }
 

--- a/main.go
+++ b/main.go
@@ -114,7 +114,10 @@ func main() {
 			setupLog.Error(err, "unable to create webhook", "webhook", "Observability")
 			os.Exit(1)
 		}
-		checkForWebhookServerReady(mgr)
+		if err = checkForWebhookServerReady(mgr); err != nil {
+			setupLog.Error(err, "problem reaching webhook server", "webhook", "Observability")
+			os.Exit(1)
+		}
 	}
 	// +kubebuilder:scaffold:builder
 


### PR DESCRIPTION
Resolves [MGDSTRM-6173](https://issues.redhat.com/browse/MGDSTRM-6173)

Check added to `main.go` to ensure webhook server is reachable before progressing operator setup.

### Verification
**Using OSD cluster**
1. Create new CatalogSource using the following image:
`quay.io/vmanley/observability-operator-index:v3.0.8`
2. Install the operator using the CatalogSource
3. Observability stack should install with no errors
4. Both the Observability and Prometheus CRs should contain the following storage claim:
```
storage:
    volumeClaimTemplate:
      metadata:
        name: managed-services
      spec:
        resources:
          requests:
            storage: 50Gi
```
5. A Persistent Volume Claim should be created with prefix `managed-services-` and a capacity of `50GiB`

**Using CRC**
1. Follow steps 1 - 4 as above
2. No Persistent Volume Claim will be observed

**Example Observability CR**

![Screenshot from 2021-11-09 11-56-56](https://user-images.githubusercontent.com/86788705/140920110-7a357fd4-694a-45e2-aac5-88519197b860.png)

**Example Persistent Volume Claim**

![Screenshot from 2021-11-09 10-47-40](https://user-images.githubusercontent.com/86788705/140919927-9d4f662b-c63a-4a87-94f6-7f73b0e8f2a0.png)



