### PR TITLE
Added support to include bearer token in blackbox exporter ConfigMap.

### DIFF
--- a/api/v1/observability_types.go
+++ b/api/v1/observability_types.go
@@ -78,6 +78,7 @@ type SelfContained struct {
 	GrafanaDashboardLabelSelector         *metav1.LabelSelector    `json:"grafanaDashboardLabelSelector,omitempty"`
 	AlertManagerConfigSecret              string                   `json:"alertManagerConfigSecret,omitempty"`
 	AlertManagerVersion                   string                   `json:"alertManagerVersion,omitempty"`
+	BlackboxBearerTokenSecret             string                   `json:"blackboxBearerTokenSecret,omitempty"`
 	PrometheusVersion                     string                   `json:"prometheusVersion,omitempty"`
 	AlertManagerResourceRequirement       v1.ResourceRequirements  `json:"alertManagerResourceRequirement,omitempty"`
 	PrometheusResourceRequirement         v1.ResourceRequirements  `json:"prometheusResourceRequirement,omitempty"`
@@ -164,6 +165,14 @@ func (in *Observability) SelfSignedCerts() bool {
 func (in *Observability) HasAlertmanagerConfigSecret() (bool, string) {
 	if in.Spec.SelfContained != nil && in.Spec.SelfContained.AlertManagerConfigSecret != "" {
 		return true, in.Spec.SelfContained.AlertManagerConfigSecret
+	}
+
+	return false, ""
+}
+
+func (in *Observability) HasBlackboxBearerTokenSecret() (bool, string) {
+	if in.Spec.SelfContained != nil && in.Spec.SelfContained.BlackboxBearerTokenSecret != "" {
+		return true, in.Spec.SelfContained.BlackboxBearerTokenSecret
 	}
 
 	return false, ""

--- a/config/crd/bases/observability.redhat.com_observabilities.yaml
+++ b/config/crd/bases/observability.redhat.com_observabilities.yaml
@@ -721,6 +721,8 @@ spec:
                     type: object
                   alertManagerVersion:
                     type: string
+                  blackboxBearerTokenSecret:
+                    type: string
                   disableBlackboxExporter:
                     type: boolean
                   disableDeadmansSnitch:

--- a/controllers/reconcilers/configuration/prometheus.go
+++ b/controllers/reconcilers/configuration/prometheus.go
@@ -75,7 +75,7 @@ func (r *Reconciler) fetchFederationConfigs(cr *v1.Observability, indexes []v1.R
 
 func (r *Reconciler) createBlackBoxConfig(cr *v1.Observability, ctx context.Context) (string, error) {
 	configMap := model.GetPrometheusBlackBoxConfig(cr)
-	cfg, hash, err := model.GetDefaultBlackBoxConfig(cr)
+	cfg, hash, err := model.GetDefaultBlackBoxConfig(cr, ctx, r.client)
 	if err != nil {
 		return hash, err
 	}


### PR DESCRIPTION
# What
The RHOAM product needs to be able to add a bearer token to the BlackboxExporter ConfigMap as part of [MGDAPI-2282](https://issues.redhat.com/browse/MGDAPI-2282).

# How
Added the field `BlackboxBearerTokenSecret` to the `SelfContained` struct of the Observability CR Spec that can hold the name of a secret whose token will act as a bearer token for the BlackboxExporter. The token is then extracted from the secret and inserted into the blackbox config.

# Verification steps
- Install the Observability Operator locally
- Create a ServiceAccount in the target namespace and note the name of the secret that is created for the ServiceAccount
- Create an observability CR with the following Spec, replacing {secret-name} with the name from the step above:
```yaml
spec:
  configurationSelector:
    matchLabels:
      monitoring-key: middleware
  resyncPeriod: 1h
  selfContained:
    alertManagerResourceRequirement: {}
    prometheusOperatorResourceRequirement: {}
    overrideSelectors: true
    prometheusResourceRequirement: {}
    grafanaOperatorResourceRequirement: {}
    disableDeadmansSnitch: true
    disablePagerDuty: true
    disableRepoSync: true
    serviceMonitorNamespaceSelector:
      matchExpressions:
        - key: monitoring-key
          operator: In
          values:
            - middleware
    blackboxBearerTokenSecret: {secret-name}
```
- Confirm that the `bearer_token` field in the `black-box-config` ConfigMap is correctly populated with secret's `token`
