### PR TITLE
fix: webhook timing issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN go mod download
 COPY main.go main.go
 COPY api/ api/
 COPY controllers/ controllers/
+COPY runners/ runners/
 
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go

--- a/main.go
+++ b/main.go
@@ -112,10 +112,11 @@ func main() {
 		}
 	}
 	// +kubebuilder:scaffold:builder
-	mgr.Add(runners.NewOperandInitializer(func() {
+	mgr.Add(runners.NewOperandInitializer(func() error {
 		if err = observabilityReconciler.InitializeOperand(mgr); err != nil {
-			setupLog.Error(err, "unable to create operand", "controller", "Observability")
+			setupLog.Error(err, "unable to create or update operand", "controller", "Observability")
 		}
+		return err
 	}))
 
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {

--- a/main.go
+++ b/main.go
@@ -35,27 +35,12 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	apiv1 "github.com/redhat-developer/observability-operator/v3/api/v1"
 	"github.com/redhat-developer/observability-operator/v3/controllers"
+	"github.com/redhat-developer/observability-operator/v3/runners"
 	// +kubebuilder:scaffold:imports
 )
-
-type OperandInitializer struct {
-	cb func()
-}
-
-func NewOperandInitializer(cb func()) manager.Runnable {
-	return &OperandInitializer{
-		cb: cb,
-	}
-}
-
-func (r *OperandInitializer) Start(<-chan struct{}) error {
-	r.cb()
-	return nil
-}
 
 var (
 	scheme   = runtime.NewScheme()
@@ -127,7 +112,7 @@ func main() {
 		}
 	}
 	// +kubebuilder:scaffold:builder
-	mgr.Add(NewOperandInitializer(func() {
+	mgr.Add(runners.NewOperandInitializer(func() {
 		if err = observabilityReconciler.InitializeOperand(mgr); err != nil {
 			setupLog.Error(err, "unable to create operand", "controller", "Observability")
 		}

--- a/runners/generic_runner.go
+++ b/runners/generic_runner.go
@@ -13,6 +13,5 @@ func NewOperandInitializer(cb func() error) manager.Runnable {
 }
 
 func (r *OperandInitializer) Start(<-chan struct{}) error {
-	err := r.cb()
-	return err
+	return r.cb()
 }

--- a/runners/generic_runner.go
+++ b/runners/generic_runner.go
@@ -1,0 +1,18 @@
+package runners
+
+import "sigs.k8s.io/controller-runtime/pkg/manager"
+
+type OperandInitializer struct {
+	cb func()
+}
+
+func NewOperandInitializer(cb func()) manager.Runnable {
+	return &OperandInitializer{
+		cb: cb,
+	}
+}
+
+func (r *OperandInitializer) Start(<-chan struct{}) error {
+	r.cb()
+	return nil
+}

--- a/runners/generic_runner.go
+++ b/runners/generic_runner.go
@@ -3,16 +3,16 @@ package runners
 import "sigs.k8s.io/controller-runtime/pkg/manager"
 
 type OperandInitializer struct {
-	cb func()
+	cb func() error
 }
 
-func NewOperandInitializer(cb func()) manager.Runnable {
+func NewOperandInitializer(cb func() error) manager.Runnable {
 	return &OperandInitializer{
 		cb: cb,
 	}
 }
 
 func (r *OperandInitializer) Start(<-chan struct{}) error {
-	r.cb()
-	return nil
+	err := r.cb()
+	return err
 }


### PR DESCRIPTION
Resolves [MGDSTRM-6173](https://issues.redhat.com/browse/MGDSTRM-6173)

Allows the Operator to avoid conflict with webhooks when adding the Prometheus storage spec

### Verification
**Using OSD cluster**
1. Create new CatalogSource using the following image:
`quay.io/vmanley/observability-operator-index:v3.0.9`
or create your own from this branch
2. Install the operator using the CatalogSource
3. Observability stack should install with no errors
4. Both the Observability and Prometheus CRs should contain the following storage claim:
```
storage:
    volumeClaimTemplate:
      metadata:
        name: managed-services
      spec:
        resources:
          requests:
            storage: 50Gi
```
5. A Persistent Volume Claim should be created with prefix `managed-services-` and a capacity of `50GiB`

**Using CRC**
1. Follow steps 1 - 4 as above
2. No Persistent Volume Claim will be observed

**Example Observability CR**

![Screenshot from 2021-11-09 11-56-56](https://user-images.githubusercontent.com/86788705/140920110-7a357fd4-694a-45e2-aac5-88519197b860.png)

**Example Persistent Volume Claim**

![Screenshot from 2021-11-09 10-47-40](https://user-images.githubusercontent.com/86788705/140919927-9d4f662b-c63a-4a87-94f6-7f73b0e8f2a0.png)