### PR TITLE
Add make targets to deploy required secrets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ manager: generate fmt vet
 
 # Run against the configured Kubernetes cluster in ~/.kube/config
 run: generate fmt vet manifests
-	go run ./main.go -disable-webhooks
+	go run ./main.go
 
 # Install CRDs into a cluster
 install: manifests kustomize
@@ -184,3 +184,4 @@ deploy/crc/secret:
 		-p DATASOURCES=${DATASOURCES} \
 		-p PROMETHEUS=${PROMETHEUS} \
 		| oc apply -f - -n openshift-monitoring
+		

--- a/README.md
+++ b/README.md
@@ -278,6 +278,45 @@ review the content of each!
       ```
       oc apply -f config/samples/secrets/observability_secret.yaml
       ```
+
+* The required secrets listed above can be configured and deployed using
+  ```
+  make deploy/secrets
+  ```
+
+    * The following parameters can be modified:
+      * NAMESPACE: Defaults to current namespace in use.
+      * OBSERVATORIUM_TENANT:       Defaults to `managedKafka`
+      * OBSERVATORIUM_GATEWAY:      Defaults to `https://observatorium-mst.api.stage.openshift.com`
+      * OBSERVATORIUM_AUTH_TYPE:    Defaults to `redhat`
+      * OBSERVATORIUM_RHSSO_URL:    Defaults to `https://sso.redhat.com/auth/`
+      * OBSERVATORIUM_RHSSO_REALM:  Defaults to `redhat-external`
+
+      * OBSERVATORIUM_RHSSO_METRICS_CLIENT_ID: **No default provided**
+      * OBSERVATORIUM_RHSSO_METRICS_SECRET: **No default provided**
+      * OBSERVATORIUM_RHSSO_LOGS_CLIENT_ID: **No default provided**
+      * OBSERVATORIUM_RHSSO_LOGS_SECRET: **No default provided**
+      * GITHUB_ACCESS_TOKEN: **No default provided**
+    * More information about configurable parameters can be found by running:
+    ```
+    oc process --parameters -f ./templates/secrets-template.yml
+    ```
+
+* For users deploying to CRC, an additional secret is required in the `openshift-monitoring` namespace for grafana datasources. This secret can be deployed with the command:
+  ```
+  make deploy/crc/secret
+  ```
+  * The following parameters can be modified:
+    * DATASOURCES: Defaults to `ZHVtbXk=`
+    * PROMETHEUS: Defaults to `ZHVtbXk=`
+
+  * More information about configurable parameters can be found by running:
+  
+  ```
+  oc process --parameters -f ./templates/crc-secret-template.yml
+  ```
+
+
 * Priority Class
   * If the Observability Operator was not installed using OLM, you need to create the requried Priority Class yourself. Use the command to add the necessary Priority Class:
   ```

--- a/templates/crc-secret-template.yml
+++ b/templates/crc-secret-template.yml
@@ -1,0 +1,23 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: observability-operator-secret-crc
+  annotations:
+    description: "Observability Operator Secret for CRC"
+parameters:
+- name: DATASOURCES
+  description: YAML file containing datasources config
+- name: PROMETHEUS
+  description: YAML file containing Prometheus datasource config
+objects:
+- kind: Secret
+  apiVersion: v1
+  metadata:
+    name: grafana-datasources
+    namespace: openshift-monitoring
+  data:
+    datasources.yaml: >-
+      ${DATASOURCES}
+    prometheus.yaml: >-
+      ${PROMETHEUS}
+  type: Opaque

--- a/templates/secrets-template.yml
+++ b/templates/secrets-template.yml
@@ -1,0 +1,69 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: observability-operator-secrets
+  annotations:
+    description: "Observability Operator Secrets"
+parameters:
+- name: OBSERVATORIUM_TENANT
+  description: Tenant for Observatorium
+- name: OBSERVATORIUM_GATEWAY
+  description: Gateway for Observatorium
+- name: OBSERVATORIUM_AUTH_TYPE
+  description: Authentication type for Observatorium
+- name: OBSERVATORIUM_RHSSO_URL
+  description: URL for Redhat SSO
+- name: OBSERVATORIUM_RHSSO_REALM
+  description: Realm for Redhat SSO
+- name: OBSERVATORIUM_RHSSO_METRICS_CLIENT_ID
+  description: Red Hat SSO Metrics client id
+- name: OBSERVATORIUM_RHSSO_METRICS_SECRET
+  description: Red Hat SSO Metrics secret
+- name: OBSERVATORIUM_RHSSO_LOGS_CLIENT_ID
+  description: Red Hat SSO Logs client id
+- name: OBSERVATORIUM_RHSSO_LOGS_SECRET
+  description: Red Hat SSO Logs secret
+- name: GITHUB_ACCESS_TOKEN
+  description: Access token for the observability resources configuration repo
+objects:
+- kind: Secret
+  apiVersion: v1
+  metadata:
+    name: observatorium-configuration-red-hat-sso
+  stringData:
+    tenant: ${OBSERVATORIUM_TENANT}
+    gateway: ${OBSERVATORIUM_GATEWAY}
+    authType: ${OBSERVATORIUM_AUTH_TYPE}  
+    redHatSsoAuthServerUrl: ${OBSERVATORIUM_RHSSO_URL}
+    redHatSsoRealm: ${OBSERVATORIUM_RHSSO_REALM}
+    metricsClientId: ${OBSERVATORIUM_RHSSO_METRICS_CLIENT_ID}
+    metricsSecret: ${OBSERVATORIUM_RHSSO_METRICS_SECRET}
+    logsClientId: ${OBSERVATORIUM_RHSSO_LOGS_CLIENT_ID}
+    logsSecret: ${OBSERVATORIUM_RHSSO_LOGS_SECRET}
+  type: Opaque
+- kind: Secret
+  apiVersion: v1
+  metadata:
+    name: kafka-observability-configuration
+    labels:
+      configures: observability-operator
+  stringData:
+    access_token: ${GITHUB_ACCESS_TOKEN}
+    channel: resources
+    tag: main
+    repository: >-
+      https://api.github.com/repos/bf2fc6cc711aee1a0c2a/observability-resources-mk/contents
+- kind: Secret
+  apiVersion: v1
+  metadata:
+    name: redhat-managed-kafka-pagerduty
+  data:
+    PAGERDUTY_KEY: ZHVtbXk=
+  type: Opaque
+- kind: Secret
+  apiVersion: v1
+  metadata:
+    name: redhat-managed-kafka-deadmanssnitch
+  data:
+    SNITCH_URL: aHR0cDovL2R1bW15
+  type: Opaque


### PR DESCRIPTION
This change allows users to setup and deploy required secrets for deployment.
The following make targets have been added to the Makefile:
```
make deploy/secrets
```
```
make deploy/crc/secret
```
`make deploy/secrets` can setup and deploy the following secrets:
* `observatorium-configuration-red-hat-sso`
* `kafka-observability-configuration`
* `redhat-managed-kafka-pagerduty`
* `redhat-managed-kafka-deadmanssnitch`

`make deploy/crc/secret` configures and deploys the `grafana-datasource` secret to the `openshift-monitoring` namespace.

Verification (OSD or CRC)
1. Use the `make deploy/secrets` target against your cluster.
2. The following secrets should be created in your current namspace/project:
     - `observatorium-configuration-red-hat-sso`
     - `kafka-observability-configuration`
     - `redhat-managed-kafka-pagerduty`
     - `redhat-managed-kafka-deadmanssnitch`
3. The `observatorium-configuration-red-hat-sso` secret should have the following blank fields:
    - `metricsClientId`
    - `metricsSecret`
    - `logsClientId`
    - `logsSecret`
4. The `kafka-observability-configuration` secret should have a blank field for `access_token`.
5. Both `redhat-managed-kafka-pagerduty` and `redhat-managed-kafka-deadmanssnitch` secrets contain dummy values
5. The blank fields of `observatorium-configuration-red-hat-sso`  and  `observatorium-configuration-red-hat-sso` can be updated by through the UI (navigate to the secret and click Actions => Edit Secret) or by running:
    ```
    make deploy/secrets OBSERVATORIUM_RHSSO_METRICS_CLIENT_ID="<metrics client id>" OBSERVATORIUM_RHSSO_METRICS_SECRET="<metrics secret>" OBSERVATORIUM_RHSSO_LOGS_CLIENT_ID="<logs client id>" OBSERVATORIUM_RHSSO_LOGS_SECRET="<logs secret>" GITHUB_ACCESS_TOKEN="access token"
    ```
6. For running on CRC, use the `make deploy/crc/secret` target against your cluster.
7. The `grafana-datasources` secret should be deployed to the `openshift-monitoring` with dummy values.
8. The dummy fields of `grafana-datasources` can be updated by through the UI (navigate to the secret and click Actions => Edit Secret) or by running:
    ```
    make deploy/crc/secret DATASOURCEs="<datasources yaml>" PROMETHEUS="<prometheus yaml>" 
    ```
9. Install and run the operator locally against your cluster. The operator should install and run successfully.