### PR TITLE
update go version and Dockerfile

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: 1.16
 
     - name: Build
       run: go build -v ./...

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi8/go-toolset:1.13.15 as builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.16.7 as builder
 
 USER root
 
@@ -22,7 +22,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager 
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5
 
 WORKDIR /
 COPY --from=builder /workspace/manager .

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ previously mentioned
 
 ### Prerequisite Tools
 
-* golang 1.15+
+* golang 1.16+
 * operator-sdk v1.1.0
 * [CodeReady Containers](https://github.com/code-ready/crc) 1.18 (OCP 4.6.1) or later
 * [OpenShift command line tool](https://developers.redhat.com/openshift/command-line-tools)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/redhat-developer/observability-operator/v3
 
-go 1.13
+go 1.16
 
 require (
 	github.com/ghodss/yaml v1.0.0


### PR DESCRIPTION
Main purpose of this PR is to update the go version. The go.mod was edited to update the go version to 1.16

Also Dockerfile was investigated as part of the same task and it was discovered that the images used for:
* [registry.access.redhat.com/ubi8/go-toolset](https://catalog.redhat.com/software/containers/ubi8/go-toolset/5ce8713aac3db925c03774d1?tag=1.13.15-1&push_date=1599577036000)
* [registry.access.redhat.com/ubi8/ubi-minimal](https://catalog.redhat.com/software/containers/ubi8-minimal/5c64772edd19c77a158ea216?tag=8.4-200&push_date=1621383400000&container-tabs=overview)
had possible security issues.
Image tags updated to latest images.
