### PR TITLE
Adds blackboxBearerTokenSecret string to bundle

### DIFF
--- a/bundle/manifests/observability.redhat.com_observabilities.yaml
+++ b/bundle/manifests/observability.redhat.com_observabilities.yaml
@@ -442,6 +442,8 @@ spec:
                     type: object
                   alertManagerVersion:
                     type: string
+                  blackboxBearerTokenSecret:
+                    type: string
                   disableBlackboxExporter:
                     type: boolean
                   disableDeadmansSnitch:


### PR DESCRIPTION
Adds the `blackboxBearerTokenSecret` string to `bundle/manifests/observability.redhat.com_observabilities.yaml` which I forgot to include in #94 