### PR TITLE
feat: increase default Prom storage size and logic to allow resources override

### DIFF
--- a/api/v1/index.go
+++ b/api/v1/index.go
@@ -86,6 +86,7 @@ type PrometheusIndex struct {
 	Federation                      string             `json:"federation,omitempty"`
 	Observatorium                   string             `json:"observatorium,omitempty"`
 	RemoteWrite                     string             `json:"remoteWrite,omitempty"`
+	OverridePrometheusPvcSize       string             `json:"overridePrometheusPvcSize,omitempty"`
 	Labels                          *v13.LabelSelector `json:"labels,omitempty"`
 	PodMonitorLabelSelector         *v13.LabelSelector `json:"podMonitorLabelSelector,omitempty"`
 	PodMonitorNamespaceSelector     *v13.LabelSelector `json:"podMonitorNamespaceSelector,omitempty"`

--- a/controllers/observability_controller.go
+++ b/controllers/observability_controller.go
@@ -4,17 +4,19 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	prometheusv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"io/ioutil"
-	storage "k8s.io/api/storage/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	"os"
 	"reflect"
 	"strings"
 	"time"
 
+	prometheusv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	storage "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
 	"github.com/go-logr/logr"
 	"github.com/prometheus-operator/prometheus-operator/pkg/k8sutil"
+	"github.com/redhat-developer/observability-operator/v3/controllers/model"
 	"github.com/redhat-developer/observability-operator/v3/controllers/reconcilers"
 	"github.com/redhat-developer/observability-operator/v3/controllers/reconcilers/alertmanager_installation"
 	"github.com/redhat-developer/observability-operator/v3/controllers/reconcilers/configuration"
@@ -344,7 +346,7 @@ func observabilityInstanceWithStorage(namespace string) apiv1.Observability {
 						Spec: v1.PersistentVolumeClaimSpec{
 							Resources: v1.ResourceRequirements{
 								Requests: map[v1.ResourceName]resource.Quantity{
-									v1.ResourceStorage: resource.MustParse("50Gi"),
+									v1.ResourceStorage: resource.MustParse(model.PrometheusDefaultStorage),
 								},
 							},
 						},


### PR DESCRIPTION
This change is to increase the default Prometheus storage size from `50Gi` to `250Gi`. Also this change will allow the Prometheus storage size to be overridden by value contained in Observability resources (see https://github.com/bf2fc6cc711aee1a0c2a/observability-resources-mk/pull/138)

### Verification
**Using OSD cluster**
1. Run this branch locally against an OSD cluster
2. Allow the operator to complete installation and check the Prometheus CR for it's storage value. CR should contain the default 250Gi storage value:
```
storage:
    volumeClaimTemplate:
      metadata:
        name: managed-services
      spec:
        resources:
          requests:
            storage: 250Gi
```
4. Find the required `kafka-observability` secret in your namespace and edit the `repository` and `tag` fields as follows:
repository: https://api.github.com/repos/vmanley/observability-resources-mk/contents
tag: test-prometheus-storage-override
5. Allow the operatorto fully reconcile the Prometheus CR.
6. Check the Prometheus CR for it's storage value. It should now read an override value of 260Gi
```
storage:
    volumeClaimTemplate:
      metadata:
        name: managed-services
      spec:
        resources:
          requests:
            storage: 260Gi
```
7. Find the required `kafka-observability` secret in your namespace and edit the `repository` and `tag` fields as follows:
repository: https://api.github.com/repos/vmanley/observability-resources-mk/contents
tag: invalid-prometheus-storage-override
8. Allow the operator to fully reconcile the Prometheus CR.
9. Check the Prometheus CR for it's storage value. It should now read the default 250Gi value:
```
storage:
    volumeClaimTemplate:
      metadata:
        name: managed-services
      spec:
        resources:
          requests:
            storage: 250Gi
```