### PR TITLE
Allow operator to support Openshift 4.10

### DIFF
--- a/controllers/reconcilers/prometheus_configuration/prometheus_configuration_reconciler.go
+++ b/controllers/reconcilers/prometheus_configuration/prometheus_configuration_reconciler.go
@@ -2,8 +2,8 @@ package prometheus_configuration
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
+
 	"github.com/go-logr/logr"
 	routev1 "github.com/openshift/api/route/v1"
 	v1 "github.com/redhat-developer/observability-operator/v3/api/v1"
@@ -375,39 +375,6 @@ func (r *Reconciler) waitForRoute(ctx context.Context, cr *v1.Observability) (v1
 	}
 
 	return v1.ResultInProgress, nil
-}
-
-func (r *Reconciler) getOpenshiftMonitoringCredentials(ctx context.Context) (string, string, error) {
-	secret := &core.Secret{}
-	selector := client.ObjectKey{
-		Namespace: "openshift-monitoring",
-		Name:      "grafana-datasources",
-	}
-
-	err := r.client.Get(ctx, selector, secret)
-	if err != nil {
-		return "", "", err
-	}
-
-	// It says yaml but it's actually json
-	j := secret.Data["prometheus.yaml"]
-
-	type datasource struct {
-		BasicAuthUser     string `json:"basicAuthUser"`
-		BasicAuthPassword string `json:"basicAuthPassword"`
-	}
-
-	type datasources struct {
-		Sources []datasource `json:"datasources"`
-	}
-
-	ds := &datasources{}
-	err = json.Unmarshal(j, ds)
-	if err != nil {
-		return "", "", err
-	}
-
-	return ds.Sources[0].BasicAuthUser, ds.Sources[0].BasicAuthPassword, nil
 }
 
 func (r *Reconciler) fetchClusterId(ctx context.Context, cr *v1.Observability, nextStatus *v1.ObservabilityStatus) (v1.ObservabilityStageStatus, error) {

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/redhat-developer/observability-operator/v3
 go 1.16
 
 require (
+	github.com/blang/semver v3.5.1+incompatible
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v0.2.1
 	github.com/go-logr/zapr v0.2.0 // indirect


### PR DESCRIPTION
This change is to allow the Operator to support Openshift v4.10+.

In Openshift v4.10.0 the `grafana-datasources` secret required by the Operator was updated:
- Name has changed to `grafana-datasources-v2`
- The `prometheus.yaml` data has been restructured. `basicAuthPassword`  has now been included as part of a new `secureJsonData` field

Example of `prometheus.yaml` in Openshift 4.9
```
{
    "apiVersion": 1,
    "datasources": [
        {
            "access": "proxy",
            "basicAuth": true,
            "basicAuthPassword": "eArKGnoEuIBKVvTz1Fb+o+t7LupNWgg1tBMRRbQ+tOOMScI9A0R+BaqT7yN8x0459xEDNNujKOoM1ztHgfYXvn81uyFfHYfMWHx1+jWBO6md1ySCTtFvLIs/OgDjAaYWXb584jYHmO/57l+JskqwxdVk/vCFsTLuTIZmgYx+BZB+nF720AmexFy2f55b+LZautm8MVUW25SdjCR+JsBYTprZLqXKPV0qpA3/es1dWPXVfWfi2+ss0iX/0GJfk3Uq4AEMnrsMoHKtevLka6fRgrSWfl/CIKCw5D+PoCB55ryh0gLN9TZFMPGclkH/VPH702HtPNp+ymarTlq3Xmil",
            "basicAuthUser": "internal",
            "editable": false,
            "jsonData": {
                "tlsSkipVerify": true
            },
            "name": "prometheus",
            "orgId": 1,
            "type": "prometheus",
            "url": "https://prometheus-k8s.openshift-monitoring.svc:9091",
            "version": 1
        }
    ]
}
```

Example of `prometheus.yaml` in Openshift 4.10
```
{
    "apiVersion": 1,
    "datasources": [
        {
            "access": "proxy",
            "basicAuth": true,
            "secureJsonData": {
                "basicAuthPassword": "v/zQ2ZxK98tGXI3pa2SLB9AOQ5AZdc1/YcqObCTDT/r9JXKAV4eHRuYhjYZMoety3qYAk40viplSqZIRT5t2wTAvqtBW7kcZWB7lqfDtNE9dCNt8n+NPOzw3rO5418U700gNRzsa/gbI9W8SqnQ2GgpHuwr9RolHP4zA1TPIHUEsfZvyhMAs+1INCk2W3wVMqRgKOC0fKuDE53f5A+i1OuMobkz9s4Vg2Cwan2pk/X9LG11nTCBiiU+ta+Osbhq2yoLTALHd3i6HPWqA70h3rEB6Yc6fe7/GR/n0DNnuKN82mSTnn/6u4Z5Ja5oFxr9ruKxAlckCWLsz+l/eBs7A"
            },
            "basicAuthUser": "internal",
            "editable": false,
            "jsonData": {
                "tlsSkipVerify": true
            },
            "name": "prometheus",
            "orgId": 1,
            "type": "prometheus",
            "url": "https://prometheus-k8s.openshift-monitoring.svc:9091",
            "version": 1
        }
    ]
}
```
These updates result in errors when installing the Operator.

This change modiifes how the Operator accesses these credentials from the required secret depending on the Openshift version it is installed on.

**Verification**
Operator should install without error on clusters using either Openshift 4.9.x or 4.10.0

Following CatalogSource can be used to deploy the Operator with this change:
```
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
  name: observability-operator-manifests
  namespace: <insert-namespace-here>
spec:
  sourceType: grpc
  image: quay.io/vmanley/observability-operator-index:3.0.9
```