### PR TITLE
Remove redundant else block

### DIFF
--- a/controllers/reconcilers/configuration/alertmanager.go
+++ b/controllers/reconcilers/configuration/alertmanager.go
@@ -219,8 +219,6 @@ func (r *Reconciler) reconcileAlertmanagerSecret(ctx context.Context, cr *v1.Obs
 					PrometheusRuleIdentifierKey: index.Id,
 				},
 			})
-		} else if (!cr.SmtpDisabled() && len(index.Config.Alertmanager.SmtpToEmailAddress) == 0) || (!cr.SmtpDisabled() && index.Config.Alertmanager.SmtpFromEmailAddress == "") {
-			r.logger.Info("both the to and from email address in the index.json file need to be set when smtp is enabled")
 		}
 	}
 


### PR DESCRIPTION
A check to see if SMTP is enabled and if the to and from email addresses are populated already exists in the `createGlobalConfig` section, so there is no need to check again, preventing duplicate log lines.