### PR TITLE
test: add tests to api/v1

### DIFF
--- a/api/v1/index_test.go
+++ b/api/v1/index_test.go
@@ -1,0 +1,258 @@
+package v1
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+var (
+	configUrl   = "red-hat-sso-config-url"
+	configRealm = "red-hat-sso-config-realm"
+)
+
+func TestIndex_HasAuthServer(t *testing.T) {
+	type fields struct {
+		Url           string
+		Realm         string
+		MetricsClient string
+		MetricsSecret string
+		LogsClient    string
+		LogsSecret    string
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		want   bool
+	}{
+		{
+			name: "true if config contains url and realm",
+			fields: fields{
+				Url:   configUrl,
+				Realm: configRealm,
+			},
+			want: true,
+		},
+		{
+			name: "false if config contains no url",
+			fields: fields{
+				Url:   "",
+				Realm: configRealm,
+			},
+			want: false,
+		},
+		{
+			name: "false if config contains no realm",
+			fields: fields{
+				Url:   configUrl,
+				Realm: "",
+			},
+			want: false,
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := &RedhatSsoConfig{
+				tt.fields.Url,
+				tt.fields.Realm,
+				tt.fields.MetricsClient,
+				tt.fields.MetricsSecret,
+				tt.fields.LogsClient,
+				tt.fields.LogsSecret,
+			}
+			result := config.HasAuthServer()
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestIndex_HasMetrics(t *testing.T) {
+	type fields struct {
+		Url           string
+		Realm         string
+		MetricsClient string
+		MetricsSecret string
+		LogsClient    string
+		LogsSecret    string
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		want   bool
+	}{
+		{
+			name: "true if config contains metrics client and secret",
+			fields: fields{
+				Url:           configUrl,
+				Realm:         configRealm,
+				MetricsClient: "metrics-client",
+				MetricsSecret: "metrics-secret",
+			},
+			want: true,
+		},
+		{
+			name: "false if config no metrics client",
+			fields: fields{
+				Url:           configUrl,
+				Realm:         configRealm,
+				MetricsClient: "",
+				MetricsSecret: "metrics-secret",
+			},
+			want: false,
+		},
+		{
+			name: "false if config no metrics secret",
+			fields: fields{
+				Url:           configUrl,
+				Realm:         configRealm,
+				MetricsClient: "metrics-client",
+				MetricsSecret: "",
+			},
+			want: false,
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := &RedhatSsoConfig{
+				tt.fields.Url,
+				tt.fields.Realm,
+				tt.fields.MetricsClient,
+				tt.fields.MetricsSecret,
+				tt.fields.LogsClient,
+				tt.fields.LogsSecret,
+			}
+			result := config.HasMetrics()
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestIndex_HasLogs(t *testing.T) {
+	type fields struct {
+		Url           string
+		Realm         string
+		MetricsClient string
+		MetricsSecret string
+		LogsClient    string
+		LogsSecret    string
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		want   bool
+	}{
+		{
+			name: "true if config contains logs client and secret",
+			fields: fields{
+				Url:        configUrl,
+				Realm:      configRealm,
+				LogsClient: "logs-client",
+				LogsSecret: "logs-secret",
+			},
+			want: true,
+		},
+		{
+			name: "false if config no metrics client",
+			fields: fields{
+				Url:        configUrl,
+				Realm:      configRealm,
+				LogsClient: "",
+				LogsSecret: "logs-secret",
+			},
+			want: false,
+		},
+		{
+			name: "false if config no metrics client",
+			fields: fields{
+				Url:        configUrl,
+				Realm:      configRealm,
+				LogsClient: "logs-client",
+				LogsSecret: "",
+			},
+			want: false,
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := &RedhatSsoConfig{
+				tt.fields.Url,
+				tt.fields.Realm,
+				tt.fields.MetricsClient,
+				tt.fields.MetricsSecret,
+				tt.fields.LogsClient,
+				tt.fields.LogsSecret,
+			}
+			result := config.HasLogs()
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestIndex_IsValid(t *testing.T) {
+	type fields struct {
+		Id              string
+		SecretName      string
+		Gateway         string
+		Tenant          string
+		AuthType        ObservabilityAuthType
+		DexConfig       *DexConfig
+		RedhatSsoConfig *RedhatSsoConfig
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		want   bool
+	}{
+		{
+			name: "true if contains gateway and tenant",
+			fields: fields{
+				Gateway: "gateway",
+				Tenant:  "tenant",
+			},
+			want: true,
+		},
+		{
+			name: "false if contains no gateway",
+			fields: fields{
+				Gateway: "",
+				Tenant:  "tenant",
+			},
+			want: false,
+		},
+		{
+			name: "true if contains no tenant",
+			fields: fields{
+				Gateway: "gateway",
+				Tenant:  "",
+			},
+			want: false,
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			obsIndex := &ObservatoriumIndex{
+				tt.fields.Id,
+				tt.fields.SecretName,
+				tt.fields.Gateway,
+				tt.fields.Tenant,
+				tt.fields.AuthType,
+				tt.fields.DexConfig,
+				tt.fields.RedhatSsoConfig,
+			}
+			result := obsIndex.IsValid()
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}

--- a/api/v1/observability_types_test.go
+++ b/api/v1/observability_types_test.go
@@ -1,0 +1,650 @@
+package v1
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const secretContent = "secret content"
+
+func TestObservabilityTypes_ExternalSyncDisabled(t *testing.T) {
+	type fields struct {
+		TypeMeta   metav1.TypeMeta
+		ObjectMeta metav1.ObjectMeta
+		Spec       ObservabilitySpec
+		Status     ObservabilityStatus
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		want   bool
+	}{
+		{
+			name: "true if spec is self contained and repo sync disabled",
+			fields: fields{
+				Spec: ObservabilitySpec{
+					SelfContained: &SelfContained{
+						DisableRepoSync: &([]bool{true})[0],
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "false if spec is not self contained",
+			fields: fields{
+				Spec: ObservabilitySpec{
+					SelfContained: nil,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "false if spec is self contained and repo sync enabled",
+			fields: fields{
+				Spec: ObservabilitySpec{
+					SelfContained: &SelfContained{
+						DisableRepoSync: &([]bool{false})[0],
+					},
+				},
+			},
+			want: false,
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			obs := &Observability{
+				tt.fields.TypeMeta,
+				tt.fields.ObjectMeta,
+				tt.fields.Spec,
+				tt.fields.Status,
+			}
+			result := obs.ExternalSyncDisabled()
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestObservabilityTypes_OverrideSelectors(t *testing.T) {
+	type fields struct {
+		TypeMeta   metav1.TypeMeta
+		ObjectMeta metav1.ObjectMeta
+		Spec       ObservabilitySpec
+		Status     ObservabilityStatus
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		want   bool
+	}{
+		{
+			name: "true if spec is self contained and override selectors is enabled",
+			fields: fields{
+				Spec: ObservabilitySpec{
+					SelfContained: &SelfContained{
+						OverrideSelectors: &([]bool{true})[0],
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "false if spec is not self contained",
+			fields: fields{
+				Spec: ObservabilitySpec{
+					SelfContained: nil,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "false if spec is self contained and override selectors disabled",
+			fields: fields{
+				Spec: ObservabilitySpec{
+					SelfContained: &SelfContained{
+						OverrideSelectors: &([]bool{false})[0],
+					},
+				},
+			},
+			want: false,
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			obs := &Observability{
+				tt.fields.TypeMeta,
+				tt.fields.ObjectMeta,
+				tt.fields.Spec,
+				tt.fields.Status,
+			}
+			result := obs.OverrideSelectors()
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestObservabilityTypes_ObservatoriumDisabled(t *testing.T) {
+	type fields struct {
+		TypeMeta   metav1.TypeMeta
+		ObjectMeta metav1.ObjectMeta
+		Spec       ObservabilitySpec
+		Status     ObservabilityStatus
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		want   bool
+	}{
+		{
+			name: "true if spec is self contained and Observatorium disabled",
+			fields: fields{
+				Spec: ObservabilitySpec{
+					SelfContained: &SelfContained{
+						DisableObservatorium: &([]bool{true})[0],
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "false if spec is not self contained",
+			fields: fields{
+				Spec: ObservabilitySpec{
+					SelfContained: nil,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "false if spec is self contained and Observatorium disabled",
+			fields: fields{
+				Spec: ObservabilitySpec{
+					SelfContained: &SelfContained{
+						DisableObservatorium: &([]bool{false})[0],
+					},
+				},
+			},
+			want: false,
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			obs := &Observability{
+				tt.fields.TypeMeta,
+				tt.fields.ObjectMeta,
+				tt.fields.Spec,
+				tt.fields.Status,
+			}
+			result := obs.ObservatoriumDisabled()
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestObservabilityTypes_PagerDutyDisabled(t *testing.T) {
+	type fields struct {
+		TypeMeta   metav1.TypeMeta
+		ObjectMeta metav1.ObjectMeta
+		Spec       ObservabilitySpec
+		Status     ObservabilityStatus
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		want   bool
+	}{
+		{
+			name: "true if spec is self contained and Pager Duty disabled",
+			fields: fields{
+				Spec: ObservabilitySpec{
+					SelfContained: &SelfContained{
+						DisablePagerDuty: &([]bool{true})[0],
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "false if spec is not self contained",
+			fields: fields{
+				Spec: ObservabilitySpec{
+					SelfContained: nil,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "false if spec is self contained and Pager Duty enabled",
+			fields: fields{
+				Spec: ObservabilitySpec{
+					SelfContained: &SelfContained{
+						DisablePagerDuty: &([]bool{false})[0],
+					},
+				},
+			},
+			want: false,
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			obs := &Observability{
+				tt.fields.TypeMeta,
+				tt.fields.ObjectMeta,
+				tt.fields.Spec,
+				tt.fields.Status,
+			}
+			result := obs.PagerDutyDisabled()
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestObservabilityTypes_DeadMansSnitchDisabled(t *testing.T) {
+	type fields struct {
+		TypeMeta   metav1.TypeMeta
+		ObjectMeta metav1.ObjectMeta
+		Spec       ObservabilitySpec
+		Status     ObservabilityStatus
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		want   bool
+	}{
+		{
+			name: "true if spec is self contained and Dead Mans Snitch disabled",
+			fields: fields{
+				Spec: ObservabilitySpec{
+					SelfContained: &SelfContained{
+						DisableDeadmansSnitch: &([]bool{true})[0],
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "false if spec is not self contained",
+			fields: fields{
+				Spec: ObservabilitySpec{
+					SelfContained: nil,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "false if spec is self contained and Dead Mans Snitch enabled",
+			fields: fields{
+				Spec: ObservabilitySpec{
+					SelfContained: &SelfContained{
+						DisableDeadmansSnitch: &([]bool{false})[0],
+					},
+				},
+			},
+			want: false,
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			obs := &Observability{
+				tt.fields.TypeMeta,
+				tt.fields.ObjectMeta,
+				tt.fields.Spec,
+				tt.fields.Status,
+			}
+			result := obs.DeadMansSnitchDisabled()
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestObservabilityTypes_SmtpDisabled(t *testing.T) {
+	type fields struct {
+		TypeMeta   metav1.TypeMeta
+		ObjectMeta metav1.ObjectMeta
+		Spec       ObservabilitySpec
+		Status     ObservabilityStatus
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		want   bool
+	}{
+		{
+			name: "true if spec is self contained and SMTP disabled",
+			fields: fields{
+				Spec: ObservabilitySpec{
+					SelfContained: &SelfContained{
+						DisableSmtp: &([]bool{true})[0],
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "false if spec is not self contained",
+			fields: fields{
+				Spec: ObservabilitySpec{
+					SelfContained: nil,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "false if spec is self contained and SMTP enabled",
+			fields: fields{
+				Spec: ObservabilitySpec{
+					SelfContained: &SelfContained{
+						DisableSmtp: &([]bool{false})[0],
+					},
+				},
+			},
+			want: false,
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			obs := &Observability{
+				tt.fields.TypeMeta,
+				tt.fields.ObjectMeta,
+				tt.fields.Spec,
+				tt.fields.Status,
+			}
+			result := obs.SmtpDisabled()
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestObservabilityTypes_BlackboxExporterDisabled(t *testing.T) {
+	type fields struct {
+		TypeMeta   metav1.TypeMeta
+		ObjectMeta metav1.ObjectMeta
+		Spec       ObservabilitySpec
+		Status     ObservabilityStatus
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		want   bool
+	}{
+		{
+			name: "true if spec is self contained and Blackbox Exporter disabled",
+			fields: fields{
+				Spec: ObservabilitySpec{
+					SelfContained: &SelfContained{
+						DisableBlackboxExporter: &([]bool{true})[0],
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "false if spec is not self contained",
+			fields: fields{
+				Spec: ObservabilitySpec{
+					SelfContained: nil,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "false if spec is self contained and Blackbox Exporter enabled",
+			fields: fields{
+				Spec: ObservabilitySpec{
+					SelfContained: &SelfContained{
+						DisableBlackboxExporter: &([]bool{false})[0],
+					},
+				},
+			},
+			want: false,
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			obs := &Observability{
+				tt.fields.TypeMeta,
+				tt.fields.ObjectMeta,
+				tt.fields.Spec,
+				tt.fields.Status,
+			}
+			result := obs.BlackboxExporterDisabled()
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestObservabilityTypes_SelfSignedCerts(t *testing.T) {
+	type fields struct {
+		TypeMeta   metav1.TypeMeta
+		ObjectMeta metav1.ObjectMeta
+		Spec       ObservabilitySpec
+		Status     ObservabilityStatus
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		want   bool
+	}{
+		{
+			name: "true if spec is self contained and self signed certs enabled",
+			fields: fields{
+				Spec: ObservabilitySpec{
+					SelfContained: &SelfContained{
+						SelfSignedCerts: &([]bool{true})[0],
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "false if spec is not self contained",
+			fields: fields{
+				Spec: ObservabilitySpec{
+					SelfContained: nil,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "false if spec is self contained and Blackbox Exporter enabled",
+			fields: fields{
+				Spec: ObservabilitySpec{
+					SelfContained: &SelfContained{
+						SelfSignedCerts: &([]bool{false})[0],
+					},
+				},
+			},
+			want: false,
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			obs := &Observability{
+				tt.fields.TypeMeta,
+				tt.fields.ObjectMeta,
+				tt.fields.Spec,
+				tt.fields.Status,
+			}
+			result := obs.SelfSignedCerts()
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestObservabilityTypes_HasAlertmanagerConfigSecret(t *testing.T) {
+	type fields struct {
+		TypeMeta   metav1.TypeMeta
+		ObjectMeta metav1.ObjectMeta
+		Spec       ObservabilitySpec
+		Status     ObservabilityStatus
+	}
+
+	type want struct {
+		exists  bool
+		content string
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		want   want
+	}{
+		{
+			name: "true if self contained and contains alert manager config secret",
+			fields: fields{
+				Spec: ObservabilitySpec{
+					SelfContained: &SelfContained{
+						AlertManagerConfigSecret: secretContent,
+					},
+				},
+			},
+			want: want{
+				exists:  true,
+				content: secretContent,
+			},
+		},
+		{
+			name: "false if spec is not self contained",
+			fields: fields{
+				Spec: ObservabilitySpec{
+					SelfContained: nil,
+				},
+			},
+			want: want{
+				exists:  false,
+				content: "",
+			},
+		},
+		{
+			name: "false if self contained and Blackbox Exporter enabled",
+			fields: fields{
+				Spec: ObservabilitySpec{
+					SelfContained: &SelfContained{
+						AlertManagerConfigSecret: "",
+					},
+				},
+			},
+			want: want{
+				exists:  false,
+				content: "",
+			},
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			obs := &Observability{
+				tt.fields.TypeMeta,
+				tt.fields.ObjectMeta,
+				tt.fields.Spec,
+				tt.fields.Status,
+			}
+			exists, content := obs.HasAlertmanagerConfigSecret()
+			Expect(exists).To(Equal(tt.want.exists))
+			Expect(content).To(Equal(tt.want.content))
+		})
+	}
+}
+
+func TestObservabilityTypes_HasBlackboxBearerTokenSecret(t *testing.T) {
+	type fields struct {
+		TypeMeta   metav1.TypeMeta
+		ObjectMeta metav1.ObjectMeta
+		Spec       ObservabilitySpec
+		Status     ObservabilityStatus
+	}
+
+	type want struct {
+		exists  bool
+		content string
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		want   want
+	}{
+		{
+			name: "true if self contained and contains black box bearer token secret",
+			fields: fields{
+				Spec: ObservabilitySpec{
+					SelfContained: &SelfContained{
+						BlackboxBearerTokenSecret: secretContent,
+					},
+				},
+			},
+			want: want{
+				exists:  true,
+				content: secretContent,
+			},
+		},
+		{
+			name: "false if not self contained",
+			fields: fields{
+				Spec: ObservabilitySpec{
+					SelfContained: nil,
+				},
+			},
+			want: want{
+				exists:  false,
+				content: "",
+			},
+		},
+		{
+			name: "false if self contained and Blackbox Exporter enabled",
+			fields: fields{
+				Spec: ObservabilitySpec{
+					SelfContained: &SelfContained{
+						BlackboxBearerTokenSecret: "",
+					},
+				},
+			},
+			want: want{
+				exists:  false,
+				content: "",
+			},
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			obs := &Observability{
+				tt.fields.TypeMeta,
+				tt.fields.ObjectMeta,
+				tt.fields.Spec,
+				tt.fields.Status,
+			}
+			exists, content := obs.HasBlackboxBearerTokenSecret()
+			Expect(exists).To(Equal(tt.want.exists))
+			Expect(content).To(Equal(tt.want.content))
+		})
+	}
+}

--- a/api/v1/observability_webhook.go
+++ b/api/v1/observability_webhook.go
@@ -18,11 +18,12 @@ package v1
 
 import (
 	"errors"
+	"strings"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
-	"strings"
 )
 
 // log is for logging in this package.
@@ -58,54 +59,57 @@ func (in *Observability) ValidateUpdate(old runtime.Object) error {
 	//	// change it if it's set already
 	// cannot remove the self contained block if it contained the value
 
+	oldObsSpec := &old.(*Observability).Spec
+	newObsSpec := &in.Spec
+
 	//AlertManagerDefaultName
-	if &old.(*Observability).Spec.AlertManagerDefaultName != nil &&
-		&in.Spec.AlertManagerDefaultName == nil {
+	if oldObsSpec.AlertManagerDefaultName != "" &&
+		newObsSpec.AlertManagerDefaultName == "" {
 		return errors.New("cannot unset AlertManagerDefaultName after cr creation")
 	}
 
-	if &old.(*Observability).Spec.AlertManagerDefaultName == nil &&
-		&in.Spec.AlertManagerDefaultName != nil {
+	if oldObsSpec.AlertManagerDefaultName == "" &&
+		newObsSpec.AlertManagerDefaultName != "" {
 		return errors.New("cannot set AlertManagerDefaultName after cr creation")
 	}
 
-	if &old.(*Observability).Spec.AlertManagerDefaultName != nil &&
-		&in.Spec.AlertManagerDefaultName != nil &&
-		strings.Compare(old.(*Observability).Spec.AlertManagerDefaultName, in.Spec.AlertManagerDefaultName) != 0 {
+	if oldObsSpec.AlertManagerDefaultName != "" &&
+		newObsSpec.AlertManagerDefaultName != "" &&
+		strings.Compare(oldObsSpec.AlertManagerDefaultName, newObsSpec.AlertManagerDefaultName) != 0 {
 		return errors.New("cannot update AlertManagerDefaultName after cr creation")
 	}
 
 	//GrafanaDefaultName
-	if &old.(*Observability).Spec.GrafanaDefaultName != nil &&
-		&in.Spec.GrafanaDefaultName == nil {
+	if oldObsSpec.GrafanaDefaultName != "" &&
+		newObsSpec.GrafanaDefaultName == "" {
 		return errors.New("cannot unset GrafanaDefaultName after cr creation")
 	}
 
-	if &old.(*Observability).Spec.GrafanaDefaultName == nil &&
-		&in.Spec.GrafanaDefaultName != nil {
+	if oldObsSpec.GrafanaDefaultName == "" &&
+		newObsSpec.GrafanaDefaultName != "" {
 		return errors.New("cannot set GrafanaDefaultName after cr creation")
 	}
 
-	if &old.(*Observability).Spec.GrafanaDefaultName != nil &&
-		&in.Spec.GrafanaDefaultName != nil &&
-		strings.Compare(old.(*Observability).Spec.GrafanaDefaultName, in.Spec.GrafanaDefaultName) != 0 {
+	if oldObsSpec.GrafanaDefaultName != "" &&
+		newObsSpec.GrafanaDefaultName != "" &&
+		strings.Compare(oldObsSpec.GrafanaDefaultName, newObsSpec.GrafanaDefaultName) != 0 {
 		return errors.New("cannot update GrafanaDefaultName after cr creation")
 	}
 
 	//PrometheusDefaultName
-	if &old.(*Observability).Spec.PrometheusDefaultName != nil &&
-		&in.Spec.PrometheusDefaultName == nil {
+	if oldObsSpec.PrometheusDefaultName != "" &&
+		newObsSpec.PrometheusDefaultName == "" {
 		return errors.New("cannot unset PrometheusDefaultName after cr creation")
 	}
 
-	if &old.(*Observability).Spec.PrometheusDefaultName == nil &&
-		&in.Spec.PrometheusDefaultName != nil {
+	if oldObsSpec.PrometheusDefaultName == "" &&
+		newObsSpec.PrometheusDefaultName != "" {
 		return errors.New("cannot set PrometheusDefaultName after cr creation")
 	}
 
-	if &old.(*Observability).Spec.PrometheusDefaultName != nil &&
-		&in.Spec.PrometheusDefaultName != nil &&
-		strings.Compare(old.(*Observability).Spec.PrometheusDefaultName, in.Spec.PrometheusDefaultName) != 0 {
+	if oldObsSpec.PrometheusDefaultName != "" &&
+		newObsSpec.PrometheusDefaultName != "" &&
+		strings.Compare(oldObsSpec.PrometheusDefaultName, newObsSpec.PrometheusDefaultName) != 0 {
 		return errors.New("cannot update PrometheusDefaultName after cr creation")
 	}
 	return nil

--- a/api/v1/observability_webhook_test.go
+++ b/api/v1/observability_webhook_test.go
@@ -1,12 +1,13 @@
 package v1
 
 import (
+	"testing"
+
 	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"testing"
 )
 
-func TestObservability_ValidateUpdate(t *testing.T) {
+func TestObservabilityWebhook_ValidateUpdate(t *testing.T) {
 	type fields struct {
 		TypeMeta   v12.TypeMeta
 		ObjectMeta v12.ObjectMeta
@@ -22,12 +23,23 @@ func TestObservability_ValidateUpdate(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
+
 		{
-			name: "AlertManagerDefaultName - error if it's old is nil and new got set",
+			name: "AlertManagerDefaultName - error if old is empty and new got set",
 			fields: fields{
 				Spec: ObservabilitySpec{
-					SelfContained: &SelfContained{},
+					AlertManagerDefaultName: "something",
 				},
+			},
+			args: args{old: &Observability{
+				Spec: ObservabilitySpec{},
+			}},
+			wantErr: true,
+		},
+		{
+			name: "AlertManagerDefaultName - error if old is set and new empty",
+			fields: fields{
+				Spec: ObservabilitySpec{},
 			},
 			args: args{old: &Observability{
 				Spec: ObservabilitySpec{
@@ -40,12 +52,12 @@ func TestObservability_ValidateUpdate(t *testing.T) {
 			name: "AlertManagerDefaultName - error if changed",
 			fields: fields{
 				Spec: ObservabilitySpec{
-					AlertManagerDefaultName: "something",
+					AlertManagerDefaultName: "somethingelse",
 				},
 			},
 			args: args{old: &Observability{
 				Spec: ObservabilitySpec{
-					AlertManagerDefaultName: "somethingelse",
+					AlertManagerDefaultName: "something",
 				},
 			}},
 			wantErr: true,
@@ -65,21 +77,21 @@ func TestObservability_ValidateUpdate(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "AlertManagerDefaultName -  no error on nil alertmanager objects",
+			name: "PrometheusDefaultName - error if old is empty and new got set",
 			fields: fields{
-				Spec: ObservabilitySpec{},
+				Spec: ObservabilitySpec{
+					PrometheusDefaultName: "something",
+				},
 			},
 			args: args{old: &Observability{
 				Spec: ObservabilitySpec{},
 			}},
-			wantErr: false,
+			wantErr: true,
 		},
 		{
-			name: "PrometheusDefaultName - error if it's old is nil and new got set",
+			name: "PrometheusDefaultName - error if old is set and new is empty",
 			fields: fields{
-				Spec: ObservabilitySpec{
-					SelfContained: &SelfContained{},
-				},
+				Spec: ObservabilitySpec{},
 			},
 			args: args{old: &Observability{
 				Spec: ObservabilitySpec{
@@ -92,12 +104,12 @@ func TestObservability_ValidateUpdate(t *testing.T) {
 			name: "PrometheusDefaultName - error if changed",
 			fields: fields{
 				Spec: ObservabilitySpec{
-					PrometheusDefaultName: "something",
+					PrometheusDefaultName: "somethingelse",
 				},
 			},
 			args: args{old: &Observability{
 				Spec: ObservabilitySpec{
-					PrometheusDefaultName: "somethingelse",
+					PrometheusDefaultName: "something",
 				},
 			}},
 			wantErr: true,
@@ -117,21 +129,19 @@ func TestObservability_ValidateUpdate(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "PrometheusDefaultName -  no error on nil prometheus objects",
+			name: "GrafanaDefaultName - error if old is nil and new got set",
 			fields: fields{
 				Spec: ObservabilitySpec{
-					AlertManagerDefaultName: "",
+					GrafanaDefaultName: "something",
 				},
 			},
 			args: args{old: &Observability{
-				Spec: ObservabilitySpec{
-					AlertManagerDefaultName: "",
-				},
+				Spec: ObservabilitySpec{},
 			}},
-			wantErr: false,
+			wantErr: true,
 		},
 		{
-			name: "GrafanaDefaultName - error if it's old is nil and new got set",
+			name: "GrafanaDefaultName - error if old is set and new is empty",
 			fields: fields{
 				Spec: ObservabilitySpec{},
 			},
@@ -146,12 +156,12 @@ func TestObservability_ValidateUpdate(t *testing.T) {
 			name: "GrafanaDefaultName - error if changed",
 			fields: fields{
 				Spec: ObservabilitySpec{
-					GrafanaDefaultName: "something",
+					GrafanaDefaultName: "somethingelse",
 				},
 			},
 			args: args{old: &Observability{
 				Spec: ObservabilitySpec{
-					GrafanaDefaultName: "somethingelse",
+					GrafanaDefaultName: "something",
 				},
 			}},
 			wantErr: true,
@@ -171,18 +181,12 @@ func TestObservability_ValidateUpdate(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "GrafanaDefaultName -  no error on nil prometheus objects",
+			name: "Common -  no error on empty objects",
 			fields: fields{
-				Spec: ObservabilitySpec{
-					AlertManagerDefaultName: "",
-					PrometheusDefaultName:   "",
-				},
+				Spec: ObservabilitySpec{},
 			},
 			args: args{old: &Observability{
-				Spec: ObservabilitySpec{
-					AlertManagerDefaultName: "",
-					PrometheusDefaultName:   "",
-				},
+				Spec: ObservabilitySpec{},
 			}},
 			wantErr: false,
 		},


### PR DESCRIPTION
## Description
Jira: [MGDSTRM-8328](https://issues.redhat.com/browse/MGDSTRM-8328)

This change increases testing coverage of api/v1 package. 

| | Current testing coverage | Coverage with this change |
| --- | --- | --- |
| api/v1/index.go | 0.0% | 100.0% |
| api/v1/observability_types.go | 6.7% | 100.0% |
| api/v1/observability_webhook.go | 56.0% | 81.5% |
| **Overall** | **3.8%** | **89.1%** |

It was found that the ValidateUpdate method in `observability_webhook.go` was performing as expected (the "cannot set..." and "cannot unset..." errors were not being returned in appropriate situations) so this method has been refactored to improve this.

Also the presence of `zz_generated.deepcopy.go` in this package distorted testing coverage (`make test/unit` reported 8.9% coverage despite all relevant files having coverage >80%). To account for this a number of changes were made to the testing make targets:
- `make test/unit` now accepts a package directory as an argument to focus testing to single package
- HTML display of coverage now given by `make test/coverage/html`
- New `make test/coverage/output` to display coverage by standard output

## Verification

- On `main` run `make test/unit`. Output should contain testing coverage for api/v1
  - For example: 
    - `ok   github.com/redhat-developer/observability-operator/v3/api/v1    0.010s  coverage: 3.2% of statements`
    
- On this PR run `make test/unit PKG=api/v1`. Output should contain testing coverage for api/v1
  - For example: 
    - `ok   github.com/redhat-developer/observability-operator/v3/api/v1    0.013s  coverage: 8.7% of statements`
- Run `make test/coverage/output` to display breakdown of testing coverage (excluding generated files) with a final total value of 89.1%
