### PR TITLE
test: added tests to controllers/model

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ pkgs = $(shell go list ./...)
 .PHONY: test/unit
 test/unit: generate fmt vet manifests
 	@if [ $(PKG) ]; then go test -coverprofile cover.out.tmp -tags unit ./$(PKG); else go test -coverprofile cover.out.tmp -tags unit $(pkgs); fi;
-	grep -v "zz_generated" cover.out.tmp > cover.out
+	grep -v -e "zz_generated" -e "priorityclass_resources.go" cover.out.tmp > cover.out
 	rm cover.out.tmp
 
 # Check coverage of unit tests and display by HTML 

--- a/controllers/model/alertmanager_resources.go
+++ b/controllers/model/alertmanager_resources.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"fmt"
+
 	routev1 "github.com/openshift/api/route/v1"
 	v12 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	v1 "github.com/redhat-developer/observability-operator/v3/api/v1"
@@ -9,8 +10,6 @@ import (
 	v14 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
-
-const AlertManagerDefaultStorage = "1Gi"
 
 func GetDefaultNameAlertmanager(cr *v1.Observability) string {
 	if cr.Spec.SelfContained != nil && cr.Spec.AlertManagerDefaultName != "" {
@@ -131,7 +130,7 @@ func GetAlertmanagerResourceRequirement(cr *v1.Observability) v13.ResourceRequir
 }
 
 func GetAlertmanagerStorageSize(cr *v1.Observability, indexes []v1.RepositoryIndex) string {
-	customAlertmanagerStorageSize := AlertManagerDefaultStorage
+	var customAlertmanagerStorageSize string
 	if cr.Spec.Storage != nil &&
 		cr.Spec.Storage.AlertManagerStorageSpec != nil &&
 		cr.Spec.Storage.AlertManagerStorageSpec.VolumeClaimTemplate.Spec.Resources.Requests != nil &&
@@ -139,14 +138,13 @@ func GetAlertmanagerStorageSize(cr *v1.Observability, indexes []v1.RepositoryInd
 		customAlertmanagerStorageSize = cr.Spec.Storage.AlertManagerStorageSpec.VolumeClaimTemplate.Spec.Resources.Requests.Storage().String()
 	}
 	alertmanagerConfig := getAlertmanagerRepositoryIndexConfig(indexes)
-	if alertmanagerConfig != nil && alertmanagerConfig.OverrideAlertmanagerPvcSize != "" {
+	if alertmanagerConfig != nil && alertmanagerConfig.OverrideAlertmanagerPvcSize != "" { //currently no override in resources repo
 		customAlertmanagerStorageSize = alertmanagerConfig.OverrideAlertmanagerPvcSize
 	}
 	return customAlertmanagerStorageSize
 }
 
 // returns the Alertmanager configuration from the repository index
-//?
 func getAlertmanagerRepositoryIndexConfig(indexes []v1.RepositoryIndex) *v1.AlertmanagerIndex {
 	if len(indexes) > 0 {
 		if indexes[0].Config != nil {

--- a/controllers/model/alertmanager_resources_test.go
+++ b/controllers/model/alertmanager_resources_test.go
@@ -7,7 +7,477 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	"testing"
+
+	. "github.com/onsi/gomega"
+	routev1 "github.com/openshift/api/route/v1"
+
+	v14 "k8s.io/api/rbac/v1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+var (
+	defaultAlertManagerName              = "kafka-alertmanager"
+	defaultAlertmanagerObjectMeta        = metav1.ObjectMeta{Name: defaultAlertManagerName}
+	alertmanagerTestName                 = "test-alert-manager-name"
+	alertmanagerServiceAccountAnnotation = map[string]string{"serviceaccounts.openshift.io/oauth-redirectreference.primary": "{\"kind\":\"OAuthRedirectReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"Route\",\"name\":\"kafka-alertmanager\"}}"}
+	testResourceList                     = map[corev1.ResourceName]resource.Quantity{corev1.ResourceStorage: resource.MustParse("10Gi")}
+)
+
+func buildObservabilityCR(modifyFn func(obsCR *v1.Observability)) *v1.Observability {
+	obsCR := &v1.Observability{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNamespace,
+		},
+		Spec: v1.ObservabilitySpec{
+			AlertManagerDefaultName: "",
+			SelfContained:           nil,
+		},
+	}
+	if modifyFn != nil {
+		modifyFn(obsCR)
+	}
+	return obsCR
+}
+
+func TestAlertManagerResources_GetDefaultNameAlertmanager(t *testing.T) {
+	type args struct {
+		cr *v1.Observability
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+
+			name: "return cr AlertManagerDefaultName if self contained",
+			args: args{
+				cr: buildObservabilityCR(func(obsCR *v1.Observability) {
+					obsCR.Spec.SelfContained = &v1.SelfContained{}
+					obsCR.Spec.AlertManagerDefaultName = alertmanagerTestName
+				}),
+			},
+			want: alertmanagerTestName,
+		},
+		{
+			name: "return `kafka-alertmanager` if NOT self contained and spec AlertManagerDefaultName is empty",
+			args: args{
+				cr: buildObservabilityCR(nil),
+			},
+			want: defaultAlertManagerName,
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetDefaultNameAlertmanager(tt.args.cr)
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestAlertManagerResources_GetAlertmanagerProxySecret(t *testing.T) {
+	type args struct {
+		cr *v1.Observability
+	}
+	tests := []struct {
+		name string
+		args args
+		want *corev1.Secret
+	}{
+		{
+			name: "return alert manager proxy secret with cr namespace",
+			args: args{
+				cr: buildObservabilityCR(nil),
+			},
+			want: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "alertmanager-proxy",
+					Namespace: testNamespace,
+				},
+			},
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetAlertmanagerProxySecret(tt.args.cr)
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestAlertManagerResources_GetAlertmanagerTLSSecret(t *testing.T) {
+	type args struct {
+		cr *v1.Observability
+	}
+	tests := []struct {
+		name string
+		args args
+		want *corev1.Secret
+	}{
+		{
+			name: "return alert manager tls secret with cr namespace",
+			args: args{
+				cr: buildObservabilityCR(nil),
+			},
+			want: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "alertmanager-k8s-tls",
+					Namespace: testNamespace,
+				},
+			},
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetAlertmanagerTLSSecret(tt.args.cr)
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestAlertManagerResources_GetAlertmanagerRoute(t *testing.T) {
+	type args struct {
+		cr *v1.Observability
+	}
+	tests := []struct {
+		name string
+		args args
+		want *routev1.Route
+	}{
+		{
+			name: "return alert manager service account with cr namespace",
+			args: args{
+				cr: buildObservabilityCR(nil),
+			},
+			want: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      defaultAlertManagerName,
+					Namespace: testNamespace,
+				},
+			},
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetAlertmanagerRoute(tt.args.cr)
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestAlertManagerResources_GetAlertmanagerServiceAccount(t *testing.T) {
+	type args struct {
+		cr *v1.Observability
+	}
+	tests := []struct {
+		name string
+		args args
+		want *corev1.ServiceAccount
+	}{
+		{
+			name: "return alert manager service account with cr namespace",
+			args: args{
+				cr: buildObservabilityCR(nil),
+			},
+			want: &corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        defaultAlertManagerName,
+					Namespace:   testNamespace,
+					Annotations: alertmanagerServiceAccountAnnotation,
+				},
+			},
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetAlertmanagerServiceAccount(tt.args.cr)
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestAlertManagerResources_GetAlertmanagerClusterRole(t *testing.T) {
+	type args struct {
+		cr *v1.Observability
+	}
+	tests := []struct {
+		name string
+		args args
+		want *v14.ClusterRole
+	}{
+		{
+			name: "return alert manager ClusterRole",
+			args: args{
+				cr: buildObservabilityCR(nil),
+			},
+			want: &v14.ClusterRole{
+				ObjectMeta: defaultAlertmanagerObjectMeta,
+			},
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetAlertmanagerClusterRole(tt.args.cr)
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestAlertManagerResources_GetAlertmanagerClusterRoleBinding(t *testing.T) {
+	type args struct {
+		cr *v1.Observability
+	}
+	tests := []struct {
+		name string
+		args args
+		want *v14.ClusterRoleBinding
+	}{
+		{
+			name: "return alert manager ClusterRoleBinding",
+			args: args{
+				cr: buildObservabilityCR(nil),
+			},
+			want: &v14.ClusterRoleBinding{
+				ObjectMeta: defaultAlertmanagerObjectMeta,
+			},
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetAlertmanagerClusterRoleBinding(tt.args.cr)
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestAlertManagerResources_GetAlertmanagerCr(t *testing.T) {
+	type args struct {
+		cr *v1.Observability
+	}
+	tests := []struct {
+		name string
+		args args
+		want *monitoringv1.Alertmanager
+	}{
+		{
+			name: "return alert manager cr",
+			args: args{
+				cr: buildObservabilityCR(nil),
+			},
+			want: &monitoringv1.Alertmanager{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      defaultAlertManagerName,
+					Namespace: testNamespace,
+				},
+			},
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetAlertmanagerCr(tt.args.cr)
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestAlertManagerResources_GetAlertmanagerSecret(t *testing.T) {
+	type args struct {
+		cr *v1.Observability
+	}
+	tests := []struct {
+		name string
+		args args
+		want *corev1.Secret
+	}{
+		{
+			name: "return alert manager cr",
+			args: args{
+				cr: buildObservabilityCR(nil),
+			},
+			want: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "alertmanager-" + defaultAlertManagerName,
+					Namespace: testNamespace,
+				},
+			},
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetAlertmanagerSecret(tt.args.cr)
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestAlertManagerResources_GetAlertmanagerSecretName(t *testing.T) {
+	type args struct {
+		cr *v1.Observability
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "return cr AlertManagerConfigSecret if self contained and AlertManagerConfigSecret not empty",
+			args: args{
+				cr: buildObservabilityCR(func(obsCR *v1.Observability) {
+					obsCR.Spec.SelfContained = &v1.SelfContained{
+						AlertManagerConfigSecret: "test",
+					}
+				}),
+			},
+			want: "test",
+		},
+		{
+			name: "return default secret name if NOT self contained",
+			args: args{
+				cr: buildObservabilityCR(nil),
+			},
+			want: "alertmanager-" + defaultAlertManagerName,
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetAlertmanagerSecretName(tt.args.cr)
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestAlertManagerResources_GetAlertmanagerService(t *testing.T) {
+	type args struct {
+		cr *v1.Observability
+	}
+	tests := []struct {
+		name string
+		args args
+		want *corev1.Service
+	}{
+		{
+			name: "return alert manager service with cr namespace",
+			args: args{
+				cr: buildObservabilityCR(nil),
+			},
+			want: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      defaultAlertManagerName,
+					Namespace: testNamespace,
+				},
+			},
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetAlertmanagerService(tt.args.cr)
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestAlertManagerResources_GetAlertmanagerVersion(t *testing.T) {
+	type args struct {
+		cr *v1.Observability
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "return alert manager version from cr when self contained",
+			args: args{
+				cr: buildObservabilityCR(func(obsCR *v1.Observability) {
+					obsCR.Spec.SelfContained = &v1.SelfContained{
+						AlertManagerVersion: "test-version",
+					}
+				}),
+			},
+			want: "test-version",
+		},
+		{
+			name: "return empty when NOT self contained",
+			args: args{
+				cr: buildObservabilityCR(nil),
+			},
+			want: "",
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetAlertmanagerVersion(tt.args.cr)
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestAlertManagerResources_GetAlertmanagerResourceRequirement(t *testing.T) {
+	type args struct {
+		cr *v1.Observability
+	}
+	tests := []struct {
+		name string
+		args args
+		want corev1.ResourceRequirements
+	}{
+		{
+			name: "return AlertManagerResourceRequirement from cr when self contained",
+			args: args{
+				cr: buildObservabilityCR(func(obsCR *v1.Observability) {
+					obsCR.Spec.SelfContained = &v1.SelfContained{
+						AlertManagerResourceRequirement: corev1.ResourceRequirements{
+							Limits: testResourceList,
+						},
+					}
+				}),
+			},
+			want: corev1.ResourceRequirements{
+				Limits: testResourceList,
+			},
+		},
+		{
+			name: "return empty ResourceRequirement when NOT self contained",
+			args: args{
+				cr: buildObservabilityCR(nil),
+			},
+			want: corev1.ResourceRequirements{},
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetAlertmanagerResourceRequirement(tt.args.cr)
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
 
 func TestGetAlertManagerStorageSize(t *testing.T) {
 	type args struct {
@@ -22,85 +492,82 @@ func TestGetAlertManagerStorageSize(t *testing.T) {
 		{
 			name: "cr storage is used when selfcontained is specified AND a storage value is provided",
 			args: args{
-				cr: &v1.Observability{
-					Spec: v1.ObservabilitySpec{
-						Storage: &v1.Storage{
-							AlertManagerStorageSpec: &monitoringv1.StorageSpec{
-								VolumeClaimTemplate: monitoringv1.EmbeddedPersistentVolumeClaim{
-									Spec: corev1.PersistentVolumeClaimSpec{
-										Resources: corev1.ResourceRequirements{
-											Requests: map[corev1.ResourceName]resource.Quantity{
-												corev1.ResourceStorage: resource.MustParse("10Gi"),
-											},
-										},
+				cr: buildObservabilityCR(func(obsCR *v1.Observability) {
+					obsCR.Spec.SelfContained = &v1.SelfContained{}
+					obsCR.Spec.Storage = &v1.Storage{
+						AlertManagerStorageSpec: &monitoringv1.StorageSpec{
+							VolumeClaimTemplate: monitoringv1.EmbeddedPersistentVolumeClaim{
+								Spec: corev1.PersistentVolumeClaimSpec{
+									Resources: corev1.ResourceRequirements{
+										Requests: testResourceList,
 									},
 								},
 							},
 						},
-						SelfContained: &v1.SelfContained{},
-					},
-				},
+					}
+				}),
 			},
 			want: "10Gi",
 		},
 		{
-			name: "default storage is used when selfcontained is NOT specified AND NO storage value is provided",
+			name: "empty string returned when selfcontained is NOT specified AND NO storage value is provided",
 			args: args{
-				cr: &v1.Observability{
-					Spec: v1.ObservabilitySpec{},
-				},
+				cr: buildObservabilityCR(nil),
 			},
-			want: "1Gi",
+			want: "",
 		},
 		{
 			name: "no nil failure when selfcontained is specified AND a storage value is NOT provided",
 			args: args{
-				cr: &v1.Observability{
-					Spec: v1.ObservabilitySpec{
-						SelfContained: &v1.SelfContained{},
-					},
-				},
+				cr: buildObservabilityCR(func(obsCR *v1.Observability) {
+					obsCR.Spec.SelfContained = &v1.SelfContained{}
+				}),
 			},
-			want: "1Gi",
+			want: "",
 		},
 		{
 			name: "no nil failure when selfcontained is specified AND PersistentVolumeClaim is NOT provided",
 			args: args{
-				cr: &v1.Observability{
-					Spec: v1.ObservabilitySpec{
-						SelfContained: &v1.SelfContained{},
-						Storage: &v1.Storage{
-							AlertManagerStorageSpec: &monitoringv1.StorageSpec{
-								VolumeClaimTemplate: monitoringv1.EmbeddedPersistentVolumeClaim{
-									Spec: corev1.PersistentVolumeClaimSpec{},
-								},
+				cr: buildObservabilityCR(func(obsCR *v1.Observability) {
+					obsCR.Spec.SelfContained = &v1.SelfContained{}
+					obsCR.Spec.Storage = &v1.Storage{
+						AlertManagerStorageSpec: &monitoringv1.StorageSpec{
+							VolumeClaimTemplate: monitoringv1.EmbeddedPersistentVolumeClaim{
+								Spec: corev1.PersistentVolumeClaimSpec{},
 							},
 						},
-					},
-				},
+					}
+				}),
 			},
-			want: "1Gi",
+			want: "",
 		},
 		{
 			name: "no nil failure when selfcontained is specified AND EmbeddedPersistentVolumeClaim is NOT provided",
 			args: args{
-				cr: &v1.Observability{
-					Spec: v1.ObservabilitySpec{
-						SelfContained: &v1.SelfContained{},
-						Storage: &v1.Storage{
-							AlertManagerStorageSpec: &monitoringv1.StorageSpec{},
-						},
-					},
-				},
+				cr: buildObservabilityCR(func(obsCR *v1.Observability) {
+					obsCR.Spec.SelfContained = &v1.SelfContained{}
+					obsCR.Spec.Storage = &v1.Storage{
+						AlertManagerStorageSpec: &monitoringv1.StorageSpec{},
+					}
+				}),
 			},
-			want: "1Gi",
+			want: "",
+		},
+		{
+			name: "returns repo PVC override size if NOT self contained and OverrideAlertmanagerPvcSize is not empty",
+			args: args{
+				cr:      buildObservabilityCR(nil),
+				indexes: testRepoIndexes,
+			},
+			want: "test-quantity",
 		},
 	}
+
+	g := NewWithT(t)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := GetAlertmanagerStorageSize(tt.args.cr, tt.args.indexes); got != tt.want {
-				t.Errorf("GetAlertManagerStorageSize() = %v, want %v", got, tt.want)
-			}
+			result := GetAlertmanagerStorageSize(tt.args.cr, tt.args.indexes)
+			g.Expect(result).To(Equal(tt.want))
 		})
 	}
 }

--- a/controllers/model/grafana_resources.go
+++ b/controllers/model/grafana_resources.go
@@ -108,7 +108,7 @@ func GetGrafanaDashboardLabelSelectors(cr *v1.Observability, indexes []v1.Reposi
 	}
 
 	return &v12.LabelSelector{
-		MatchLabels: defaultPrometheusLabelSelectors,
+		MatchLabels: defaultGrafanaLabelSelectors,
 	}
 }
 func GetGrafanaResourceRequirement(cr *v1.Observability) *v14.ResourceRequirements {

--- a/controllers/model/grafana_resources_test.go
+++ b/controllers/model/grafana_resources_test.go
@@ -1,0 +1,466 @@
+package model
+
+import (
+	"testing"
+
+	v1alpha12 "github.com/integr8ly/grafana-operator/v3/pkg/apis/integreatly/v1alpha1"
+	. "github.com/onsi/gomega"
+	coreosv1 "github.com/operator-framework/api/pkg/operators/v1"
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	v1 "github.com/redhat-developer/observability-operator/v3/api/v1"
+	corev1 "k8s.io/api/core/v1"
+	v14 "k8s.io/api/rbac/v1"
+	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	defaultGrafanaName         = "kafka-grafana"
+	objectMetaWithNamespace    = v12.ObjectMeta{Namespace: testNamespace}
+	labelSelectorWithNamespace = &v12.LabelSelector{MatchLabels: map[string]string{"namespace": "test"}}
+)
+
+func TestGrafanaResources_GetDefaultNameGrafana(t *testing.T) {
+	type args struct {
+		cr *v1.Observability
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "returns 'kafka-grafana' if NOT self contained",
+			args: args{
+				cr: buildObservabilityCR(nil),
+			},
+			want: defaultGrafanaName,
+		},
+		{
+			name: "returns CR default Grafana name if self contained",
+			args: args{
+				cr: buildObservabilityCR(func(obsCR *v1.Observability) {
+					obsCR.Spec.SelfContained = &v1.SelfContained{}
+					obsCR.Spec.GrafanaDefaultName = "test"
+				}),
+			},
+			want: "test",
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetDefaultNameGrafana(tt.args.cr)
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestGrafanaResources_GetGrafanaCatalogSource(t *testing.T) {
+	type args struct {
+		cr *v1.Observability
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want *v1alpha1.CatalogSource
+	}{
+		{
+			name: "returns 'grafana-operator-catalog-source' CatalogSource",
+			args: args{
+				cr: buildObservabilityCR(func(obsCR *v1.Observability) {
+					obsCR.ObjectMeta = objectMetaWithNamespace
+				}),
+			},
+			want: &v1alpha1.CatalogSource{
+				ObjectMeta: v12.ObjectMeta{
+					Name:      "grafana-operator-catalog-source",
+					Namespace: testNamespace,
+				},
+			},
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetGrafanaCatalogSource(tt.args.cr)
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestGrafanaResources_GetGrafanaSubscription(t *testing.T) {
+	type args struct {
+		cr *v1.Observability
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want *v1alpha1.Subscription
+	}{
+		{
+			name: "returns 'grafana-subscription' Subscription",
+			args: args{
+				cr: buildObservabilityCR(func(obsCR *v1.Observability) {
+					obsCR.ObjectMeta = objectMetaWithNamespace
+				}),
+			},
+			want: &v1alpha1.Subscription{
+				ObjectMeta: v12.ObjectMeta{
+					Name:      "grafana-subscription",
+					Namespace: testNamespace,
+				},
+			},
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetGrafanaSubscription(tt.args.cr)
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestGrafanaResources_GetGrafanaOperatorGroup(t *testing.T) {
+	type args struct {
+		cr *v1.Observability
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want *coreosv1.OperatorGroup
+	}{
+		{
+			name: "returns 'observability-operatorgroup' OperatorGroup",
+			args: args{
+				cr: buildObservabilityCR(func(obsCR *v1.Observability) {
+					obsCR.ObjectMeta = objectMetaWithNamespace
+				}),
+			},
+			want: &coreosv1.OperatorGroup{
+				ObjectMeta: v12.ObjectMeta{
+					Name:      "observability-operatorgroup",
+					Namespace: testNamespace,
+				},
+			},
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetGrafanaOperatorGroup(tt.args.cr)
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestGrafanaResources_GetGrafanaProxySecret(t *testing.T) {
+	type args struct {
+		cr *v1.Observability
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want *corev1.Secret
+	}{
+		{
+			name: "returns 'grafana-k8s-proxy' Secret",
+			args: args{
+				cr: buildObservabilityCR(func(obsCR *v1.Observability) {
+					obsCR.ObjectMeta = objectMetaWithNamespace
+				}),
+			},
+			want: &corev1.Secret{
+				ObjectMeta: v12.ObjectMeta{
+					Name:      "grafana-k8s-proxy",
+					Namespace: testNamespace,
+				},
+			},
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetGrafanaProxySecret(tt.args.cr)
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestGrafanaResources_GetGrafanaClusterRole(t *testing.T) {
+	type args struct {
+		cr *v1.Observability
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want *v14.ClusterRole
+	}{
+		{
+			name: "returns Grafana ClusterRole",
+			args: args{
+				cr: buildObservabilityCR(nil),
+			},
+			want: &v14.ClusterRole{
+				ObjectMeta: v12.ObjectMeta{
+					Name: "grafana-oauth-proxy-cluster-role",
+				},
+			},
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetGrafanaClusterRole(tt.args.cr)
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestGrafanaResources_GetGrafanaClusterRoleBinding(t *testing.T) {
+	type args struct {
+		cr *v1.Observability
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want *v14.ClusterRoleBinding
+	}{
+		{
+			name: "returns Grafana ClusterRoleBinding",
+			args: args{
+				cr: buildObservabilityCR(nil),
+			},
+			want: &v14.ClusterRoleBinding{
+				ObjectMeta: v12.ObjectMeta{
+					Name: "cluster-grafana-oauth-proxy-cluster-role-binding",
+				},
+			},
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetGrafanaClusterRoleBinding(tt.args.cr)
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestGrafanaResources_GetGrafanaCr(t *testing.T) {
+	type args struct {
+		cr *v1.Observability
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want *v1alpha12.Grafana
+	}{
+		{
+			name: "returns Grafana CR",
+			args: args{
+				cr: buildObservabilityCR(nil),
+			},
+			want: &v1alpha12.Grafana{
+				ObjectMeta: v12.ObjectMeta{
+					Name:      defaultGrafanaName,
+					Namespace: testNamespace,
+				},
+			},
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetGrafanaCr(tt.args.cr)
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestGrafanaResources_GetGrafanaDatasource(t *testing.T) {
+	type args struct {
+		cr *v1.Observability
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want *v1alpha12.GrafanaDataSource
+	}{
+		{
+			name: "returns Grafana datasource",
+			args: args{
+				cr: buildObservabilityCR(nil),
+			},
+			want: &v1alpha12.GrafanaDataSource{
+				ObjectMeta: v12.ObjectMeta{
+					Name:      "on-cluster-prometheus",
+					Namespace: testNamespace,
+				},
+			},
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetGrafanaDatasource(tt.args.cr)
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestGrafanaResources_GetGrafanaDashboardLabelSelectors(t *testing.T) {
+	type args struct {
+		cr      *v1.Observability
+		indexes []v1.RepositoryIndex
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want *v12.LabelSelector
+	}{
+		{
+			name: "returns CR GrafanaDashboardLabelSelector when self contained",
+			args: args{
+				cr: buildObservabilityCR(func(obsCR *v1.Observability) {
+					obsCR.Spec.SelfContained = &v1.SelfContained{
+						GrafanaDashboardLabelSelector: labelSelectorWithNamespace,
+					}
+				}),
+				indexes: []v1.RepositoryIndex{},
+			},
+			want: labelSelectorWithNamespace,
+		},
+		{
+			name: "returns Grafana dashboard LabelSelector from repo Grafana Index",
+			args: args{
+				cr:      buildObservabilityCR(nil),
+				indexes: testRepoIndexes,
+			},
+			want: labelSelectorWithNamespace,
+		},
+		{
+			name: "returns default Grafana dashboard LabelSelector when self contained is nil and no repo config",
+			args: args{
+				cr:      buildObservabilityCR(nil),
+				indexes: []v1.RepositoryIndex{},
+			},
+			want: &v12.LabelSelector{
+				MatchLabels: defaultGrafanaLabelSelectors,
+			},
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetGrafanaDashboardLabelSelectors(tt.args.cr, tt.args.indexes)
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestGrafanaResources_GetGrafanaResourceRequirement(t *testing.T) {
+	type args struct {
+		cr *v1.Observability
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want *corev1.ResourceRequirements
+	}{
+		{
+			name: "returns empty ResourceRequirments if NOT self contained",
+			args: args{
+				cr: buildObservabilityCR(nil),
+			},
+			want: &corev1.ResourceRequirements{},
+		},
+		{
+			name: "returns CR GrafanaResourceRequirement if self contained",
+			args: args{
+				cr: buildObservabilityCR(func(obsCR *v1.Observability) {
+					obsCR.Spec.SelfContained = &v1.SelfContained{
+						GrafanaResourceRequirement: &corev1.ResourceRequirements{
+							Limits: testResourceList,
+						},
+					}
+				}),
+			},
+			want: &corev1.ResourceRequirements{
+				Limits: testResourceList,
+			},
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetGrafanaResourceRequirement(tt.args.cr)
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestGrafanaResources_GetGrafanaOperatorResourceRequirement(t *testing.T) {
+	type args struct {
+		cr *v1.Observability
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want corev1.ResourceRequirements
+	}{
+		{
+			name: "returns empty ResourceRequirments if NOT self contained",
+			args: args{
+				cr: buildObservabilityCR(nil),
+			},
+			want: corev1.ResourceRequirements{},
+		},
+		{
+			name: "returns CR GrafanaOperatorResourceRequirement if self contained",
+			args: args{
+				cr: buildObservabilityCR(func(obsCR *v1.Observability) {
+					obsCR.Spec.SelfContained = &v1.SelfContained{
+						GrafanaOperatorResourceRequirement: corev1.ResourceRequirements{
+							Limits: testResourceList,
+						},
+					}
+				}),
+			},
+			want: corev1.ResourceRequirements{
+				Limits: testResourceList,
+			},
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetGrafanaOperatorResourceRequirement(tt.args.cr)
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}

--- a/controllers/model/prometheus_resources.go
+++ b/controllers/model/prometheus_resources.go
@@ -477,7 +477,8 @@ func GetPrometheusOperatorResourceRequirement(cr *v1.Observability) v13.Resource
 }
 func GetPrometheusStorageSize(cr *v1.Observability, indexes []v1.RepositoryIndex) string {
 	customPrometheusStorageSize := PrometheusDefaultStorage
-	if cr.Spec.Storage != nil &&
+	if cr.Spec.SelfContained != nil &&
+		cr.Spec.Storage != nil &&
 		cr.Spec.Storage.PrometheusStorageSpec != nil &&
 		cr.Spec.Storage.PrometheusStorageSpec.VolumeClaimTemplate.Spec.Resources.Requests != nil &&
 		cr.Spec.Storage.PrometheusStorageSpec.VolumeClaimTemplate.Spec.Resources.Requests.Storage() != nil {

--- a/controllers/model/prometheus_resources_test.go
+++ b/controllers/model/prometheus_resources_test.go
@@ -1,15 +1,1311 @@
 package model
 
 import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	routev1 "github.com/openshift/api/route/v1"
+	coreosv1 "github.com/operator-framework/api/pkg/operators/v1"
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	v1 "github.com/redhat-developer/observability-operator/v3/api/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
-
-	"testing"
+	v14 "k8s.io/api/rbac/v1"
+	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestGetPrometheusStorageSize(t *testing.T) {
+var (
+	objectMetaWithPrometheusName       = v12.ObjectMeta{Name: defaultPrometheusName}
+	testNamespace                      = "testNamespace"
+	defaultPrometheusName              = "kafka-prometheus"
+	serviceAccountPrometheusAnnotation = map[string]string{"serviceaccounts.openshift.io/oauth-redirectreference.primary": "{\"kind\":\"OAuthRedirectReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"Route\",\"name\":\"kafka-prometheus\"}}"}
+	testPattern                        = []string{"test1", "test2"}
+	testFederationConfig               = `
+- job_name: openshift-monitoring-federation
+  honor_labels: true
+  kubernetes_sd_configs:
+    - role: service
+      namespaces:
+        names:
+          - openshift-monitoring
+  scrape_interval: 120s
+  scrape_timeout: 60s
+  metrics_path: /federate
+  relabel_configs:
+    - action: keep
+      source_labels: [ '__meta_kubernetes_service_name' ]
+      regex: prometheus-k8s
+    - action: keep
+      source_labels: [ '__meta_kubernetes_service_port_name' ]
+      regex: web
+  params:
+    match[]: [test1,test2]
+  scheme: https
+  tls_config:
+    insecure_skip_verify: true
+  basic_auth:
+    username: testuser
+    password: testpass
+`
+	configAsByteArray = []byte(testFederationConfig)
+	testRepoIndexes   = []v1.RepositoryIndex{
+		{
+			Config: &v1.RepositoryConfig{
+				Grafana: &v1.GrafanaIndex{
+					DashboardLabelSelector: labelSelectorWithNamespace,
+				},
+				Prometheus: &v1.PrometheusIndex{
+					ProbeNamespaceSelector:          labelSelectorWithNamespace,
+					PodMonitorLabelSelector:         labelSelectorWithNamespace,
+					ServiceMonitorLabelSelector:     labelSelectorWithNamespace,
+					RuleLabelSelector:               labelSelectorWithNamespace,
+					ProbeLabelSelector:              labelSelectorWithNamespace,
+					PodMonitorNamespaceSelector:     labelSelectorWithNamespace,
+					ServiceMonitorNamespaceSelector: labelSelectorWithNamespace,
+					RuleNamespaceSelector:           labelSelectorWithNamespace,
+					OverridePrometheusPvcSize:       "test-quantity",
+				},
+				Alertmanager: &v1.AlertmanagerIndex{
+					OverrideAlertmanagerPvcSize: "test-quantity",
+				},
+			},
+		},
+		{
+			Config: &v1.RepositoryConfig{
+				Promtail: &v1.PromtailIndex{
+					DaemonSetLabelSelector: &v12.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "promtail-test",
+						},
+					},
+				},
+			},
+		},
+	}
+)
+
+func TestPrometheusResources_GetDefaultNamePrometheus(t *testing.T) {
+	type args struct {
+		cr *v1.Observability
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "returns 'kafka-prometheus' if NOT self contained",
+			args: args{
+				cr: buildObservabilityCR(nil),
+			},
+			want: defaultPrometheusName,
+		},
+		{
+			name: "returns CR default Prometheus name if self contained",
+			args: args{
+				cr: buildObservabilityCR(func(obsCR *v1.Observability) {
+					obsCR.Spec.SelfContained = &v1.SelfContained{}
+					obsCR.Spec.PrometheusDefaultName = "test"
+				}),
+			},
+			want: "test",
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetDefaultNamePrometheus(tt.args.cr)
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestPrometheusResources_GetPrometheusAuthTokenLifetimes(t *testing.T) {
+	type args struct {
+		cr *v1.Observability
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want *corev1.ConfigMap
+	}{
+		{
+			name: "returns 'observatorium-token-lifetimes' ConfigMap",
+			args: args{
+				cr: buildObservabilityCR(nil),
+			},
+			want: &corev1.ConfigMap{
+				ObjectMeta: v12.ObjectMeta{
+					Name:      "observatorium-token-lifetimes",
+					Namespace: testNamespace,
+				},
+			},
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetPrometheusAuthTokenLifetimes(tt.args.cr)
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestPrometheusResources_GetPrometheusOperatorgroup(t *testing.T) {
+	type args struct {
+		cr *v1.Observability
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want *coreosv1.OperatorGroup
+	}{
+		{
+			name: "returns 'observability-operatorgroup' OperatorGroup",
+			args: args{
+				cr: buildObservabilityCR(nil),
+			},
+			want: &coreosv1.OperatorGroup{
+				ObjectMeta: v12.ObjectMeta{
+					Name:      "observability-operatorgroup",
+					Namespace: testNamespace,
+				},
+			},
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetPrometheusOperatorgroup(tt.args.cr)
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestPrometheusResources_GetPrometheusSubscription(t *testing.T) {
+	type args struct {
+		cr *v1.Observability
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want *v1alpha1.Subscription
+	}{
+		{
+			name: "returns 'prometheus-subscription' Subscription",
+			args: args{
+				cr: buildObservabilityCR(nil),
+			},
+			want: &v1alpha1.Subscription{
+				ObjectMeta: v12.ObjectMeta{
+					Name:      "prometheus-subscription",
+					Namespace: testNamespace,
+				},
+			},
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetPrometheusSubscription(tt.args.cr)
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestPrometheusResources_GetPrometheusCatalogSource(t *testing.T) {
+	type args struct {
+		cr *v1.Observability
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want *v1alpha1.CatalogSource
+	}{
+		{
+			name: "returns 'prometheus-catalogsource' CatalogSource",
+			args: args{
+				cr: buildObservabilityCR(nil),
+			},
+			want: &v1alpha1.CatalogSource{
+				ObjectMeta: v12.ObjectMeta{
+					Name:      "prometheus-catalogsource",
+					Namespace: testNamespace,
+				},
+			},
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetPrometheusCatalogSource(tt.args.cr)
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestPrometheusResources_GetPrometheusProxySecret(t *testing.T) {
+	type args struct {
+		cr *v1.Observability
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want *corev1.Secret
+	}{
+		{
+			name: "returns 'prometheus-proxy' Secret",
+			args: args{
+				cr: buildObservabilityCR(nil),
+			},
+			want: &corev1.Secret{
+				ObjectMeta: v12.ObjectMeta{
+					Name:      "prometheus-proxy",
+					Namespace: testNamespace,
+				},
+			},
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetPrometheusProxySecret(tt.args.cr)
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestPrometheusResources_GetPrometheusTLSSecret(t *testing.T) {
+	type args struct {
+		cr *v1.Observability
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want *corev1.Secret
+	}{
+		{
+			name: "returns 'prometheus-k8s-tls' Secret",
+			args: args{
+				cr: buildObservabilityCR(nil),
+			},
+			want: &corev1.Secret{
+				ObjectMeta: v12.ObjectMeta{
+					Name:      "prometheus-k8s-tls",
+					Namespace: testNamespace,
+				},
+			},
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetPrometheusTLSSecret(tt.args.cr)
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestPrometheusResources_GetPrometheusServiceAccount(t *testing.T) {
+	type args struct {
+		cr *v1.Observability
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want *corev1.ServiceAccount
+	}{
+		{
+			name: "returns prometheus service account",
+			args: args{
+				cr: buildObservabilityCR(nil),
+			},
+			want: &corev1.ServiceAccount{
+				ObjectMeta: v12.ObjectMeta{
+					Name:        defaultPrometheusName,
+					Namespace:   testNamespace,
+					Annotations: serviceAccountPrometheusAnnotation,
+				},
+			},
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetPrometheusServiceAccount(tt.args.cr)
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestPrometheusResources_GetPrometheusService(t *testing.T) {
+	type args struct {
+		cr *v1.Observability
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want *corev1.Service
+	}{
+		{
+			name: "returns prometheus service",
+			args: args{
+				cr: buildObservabilityCR(nil),
+			},
+			want: &corev1.Service{
+				ObjectMeta: v12.ObjectMeta{
+					Name:      defaultPrometheusName,
+					Namespace: testNamespace,
+				},
+			},
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetPrometheusService(tt.args.cr)
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestPrometheusResources_GetPrometheusClusterRole(t *testing.T) {
+	type args struct {
+		cr *v1.Observability
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want *v14.ClusterRole
+	}{
+		{
+			name: "returns Prometheus ClusterRole",
+			args: args{
+				cr: buildObservabilityCR(nil),
+			},
+			want: &v14.ClusterRole{
+				ObjectMeta: objectMetaWithPrometheusName,
+			},
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetPrometheusClusterRole(tt.args.cr)
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestPrometheusResources_GetPrometheusClusterRoleBinding(t *testing.T) {
+	type args struct {
+		cr *v1.Observability
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want *v14.ClusterRoleBinding
+	}{
+		{
+			name: "returns Prometheus ClusterRoleBinding",
+			args: args{
+				cr: buildObservabilityCR(nil),
+			},
+			want: &v14.ClusterRoleBinding{
+				ObjectMeta: objectMetaWithPrometheusName,
+			},
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetPrometheusClusterRoleBinding(tt.args.cr)
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestPrometheusResources_GetPrometheusRoute(t *testing.T) {
+	type args struct {
+		cr *v1.Observability
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want *routev1.Route
+	}{
+		{
+			name: "returns Prometheus route",
+			args: args{
+				cr: buildObservabilityCR(func(obsCR *v1.Observability) {
+					obsCR.ObjectMeta = objectMetaWithNamespace
+				}),
+			},
+			want: &routev1.Route{
+				ObjectMeta: v12.ObjectMeta{
+					Name:      defaultPrometheusName,
+					Namespace: testNamespace,
+				},
+			},
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetPrometheusRoute(tt.args.cr)
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestPrometheusResources_GetFederationConfig(t *testing.T) {
+	type args struct {
+		user     string
+		pass     string
+		patterns []string
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+		want    []byte
+	}{
+		{
+			name: "returns correct federation config with no error",
+			args: args{
+				user:     "testuser",
+				pass:     "testpass",
+				patterns: testPattern,
+			},
+			wantErr: false,
+			want:    configAsByteArray,
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := GetFederationConfig(tt.args.user, tt.args.pass, tt.args.patterns)
+			Expect(err != nil).To(Equal(tt.wantErr))
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestPrometheusResources_GetPrometheusAdditionalScrapeConfig(t *testing.T) {
+	type args struct {
+		cr *v1.Observability
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want *corev1.Secret
+	}{
+		{
+			name: "returns Prometheus additional scrape configs",
+			args: args{
+				cr: buildObservabilityCR(func(obsCR *v1.Observability) {
+					obsCR.ObjectMeta = objectMetaWithNamespace
+				}),
+			},
+			want: &corev1.Secret{
+				ObjectMeta: v12.ObjectMeta{
+					Name:      "additional-scrape-configs",
+					Namespace: testNamespace,
+				},
+			},
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetPrometheusAdditionalScrapeConfig(tt.args.cr)
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestPrometheusResources_GetPrometheusBlackBoxConfig(t *testing.T) {
+	type args struct {
+		cr *v1.Observability
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want *corev1.ConfigMap
+	}{
+		{
+			name: "returns Prometheus black box config",
+			args: args{
+				cr: buildObservabilityCR(func(obsCR *v1.Observability) {
+					obsCR.ObjectMeta = objectMetaWithNamespace
+				}),
+			},
+			want: &corev1.ConfigMap{
+				ObjectMeta: v12.ObjectMeta{
+					Name:      "black-box-config",
+					Namespace: testNamespace,
+					Labels: map[string]string{
+						"managed-by": "observability-operator",
+					},
+				},
+			},
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetPrometheusBlackBoxConfig(tt.args.cr)
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestPrometheusResources_GetPrometheus(t *testing.T) {
+	type args struct {
+		cr *v1.Observability
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want *monitoringv1.Prometheus
+	}{
+		{
+			name: "returns Prometheus",
+			args: args{
+				cr: buildObservabilityCR(func(obsCR *v1.Observability) {
+					obsCR.ObjectMeta = objectMetaWithNamespace
+				}),
+			},
+			want: &monitoringv1.Prometheus{
+				ObjectMeta: v12.ObjectMeta{
+					Name:      defaultPrometheusName,
+					Namespace: testNamespace,
+				},
+			},
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetPrometheus(tt.args.cr)
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestPrometheusResources_GetDeadmansSwitch(t *testing.T) {
+	type args struct {
+		cr *v1.Observability
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want *monitoringv1.PrometheusRule
+	}{
+		{
+			name: "returns PrometheusRule for Dead Mans Switch alert",
+			args: args{
+				cr: buildObservabilityCR(func(obsCR *v1.Observability) {
+					obsCR.ObjectMeta = objectMetaWithNamespace
+				}),
+			},
+			want: &monitoringv1.PrometheusRule{
+				ObjectMeta: v12.ObjectMeta{
+					Name:      "generated-deadmansswitch",
+					Namespace: testNamespace,
+				},
+			},
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetDeadmansSwitch(tt.args.cr)
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestPrometheusResources_GetPrometheusPodMonitorLabelSelectors(t *testing.T) {
+	type args struct {
+		cr      *v1.Observability
+		indexes []v1.RepositoryIndex
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want *v12.LabelSelector
+	}{
+		{
+			name: "returns CR PodMonitorLabelSelector when self contained",
+			args: args{
+				cr: buildObservabilityCR(func(obsCR *v1.Observability) {
+					obsCR.Spec.SelfContained = &v1.SelfContained{
+						PodMonitorLabelSelector: labelSelectorWithNamespace,
+					}
+				}),
+				indexes: []v1.RepositoryIndex{},
+			},
+			want: labelSelectorWithNamespace,
+		},
+		{
+			name: "returns blank LabelSelector when self contained selector is nil and selectors are overridden",
+			args: args{
+				cr: buildObservabilityCR(func(obsCR *v1.Observability) {
+					obsCR.Spec.SelfContained = &v1.SelfContained{
+						PodMonitorLabelSelector: nil,
+						OverrideSelectors:       &([]bool{true})[0],
+					}
+				}),
+				indexes: []v1.RepositoryIndex{},
+			},
+			want: &v12.LabelSelector{},
+		},
+		{
+			name: "returns pod monitor LabelSelector from repo Prometheus Index",
+			args: args{
+				cr:      buildObservabilityCR(nil),
+				indexes: testRepoIndexes,
+			},
+			want: labelSelectorWithNamespace,
+		},
+		{
+			name: "returns default pod monitor LabelSelector when self contained is nil and no repo config",
+			args: args{
+				cr:      buildObservabilityCR(nil),
+				indexes: []v1.RepositoryIndex{},
+			},
+			want: &v12.LabelSelector{
+				MatchLabels: defaultPrometheusLabelSelectors,
+			},
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetPrometheusPodMonitorLabelSelectors(tt.args.cr, tt.args.indexes)
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestPrometheusResources_GetPrometheusServiceMonitorLabelSelectors(t *testing.T) {
+	type args struct {
+		cr      *v1.Observability
+		indexes []v1.RepositoryIndex
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want *v12.LabelSelector
+	}{
+		{
+			name: "returns CR ServiceMonitorLabelSelector when self contained",
+			args: args{
+				cr: buildObservabilityCR(func(obsCR *v1.Observability) {
+					obsCR.Spec.SelfContained = &v1.SelfContained{
+						ServiceMonitorLabelSelector: labelSelectorWithNamespace,
+					}
+				}),
+				indexes: []v1.RepositoryIndex{},
+			},
+			want: labelSelectorWithNamespace,
+		},
+		{
+			name: "returns blank LabelSelector when self contained selector is nil and selectors are overridden",
+			args: args{
+				cr: buildObservabilityCR(func(obsCR *v1.Observability) {
+					obsCR.Spec.SelfContained = &v1.SelfContained{
+						ServiceMonitorLabelSelector: nil,
+						OverrideSelectors:           &([]bool{true})[0],
+					}
+				}),
+				indexes: []v1.RepositoryIndex{},
+			},
+			want: &v12.LabelSelector{},
+		},
+		{
+			name: "returns service monitor LabelSelector from repo Prometheus Index",
+			args: args{
+				cr: &v1.Observability{
+					Spec: v1.ObservabilitySpec{
+						SelfContained: nil,
+					},
+				},
+				indexes: testRepoIndexes,
+			},
+			want: labelSelectorWithNamespace,
+		},
+		{
+			name: "returns default service monitor LabelSelector when self contained is nil and no repo config",
+			args: args{
+				cr:      buildObservabilityCR(nil),
+				indexes: []v1.RepositoryIndex{},
+			},
+			want: &v12.LabelSelector{
+				MatchLabels: defaultPrometheusLabelSelectors,
+			},
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetPrometheusServiceMonitorLabelSelectors(tt.args.cr, tt.args.indexes)
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestPrometheusResources_GetPrometheusRuleLabelSelectors(t *testing.T) {
+	type args struct {
+		cr      *v1.Observability
+		indexes []v1.RepositoryIndex
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want *v12.LabelSelector
+	}{
+		{
+			name: "returns CR RuleLabelSelector when self contained",
+			args: args{
+				cr: buildObservabilityCR(func(obsCR *v1.Observability) {
+					obsCR.Spec.SelfContained = &v1.SelfContained{
+						RuleLabelSelector: labelSelectorWithNamespace,
+					}
+				}),
+				indexes: []v1.RepositoryIndex{},
+			},
+			want: labelSelectorWithNamespace,
+		},
+		{
+			name: "returns blank LabelSelector when self contained selector is nil and selectors are overridden",
+			args: args{
+				cr: buildObservabilityCR(func(obsCR *v1.Observability) {
+					obsCR.Spec.SelfContained = &v1.SelfContained{
+						RuleLabelSelector: nil,
+						OverrideSelectors: &([]bool{true})[0],
+					}
+				}),
+				indexes: []v1.RepositoryIndex{},
+			},
+			want: &v12.LabelSelector{},
+		},
+		{
+			name: "returns Prometheus rule LabelSelector from repo Prometheus Index",
+			args: args{
+				cr:      buildObservabilityCR(nil),
+				indexes: testRepoIndexes,
+			},
+			want: labelSelectorWithNamespace,
+		},
+		{
+			name: "returns default Prometheus rule LabelSelector when self contained is nil and no repo config",
+			args: args{
+				cr:      buildObservabilityCR(nil),
+				indexes: []v1.RepositoryIndex{},
+			},
+			want: &v12.LabelSelector{
+				MatchLabels: defaultPrometheusLabelSelectors,
+			},
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetPrometheusRuleLabelSelectors(tt.args.cr, tt.args.indexes)
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestPrometheusResources_GetProbeLabelSelectors(t *testing.T) {
+	type args struct {
+		cr      *v1.Observability
+		indexes []v1.RepositoryIndex
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want *v12.LabelSelector
+	}{
+		{
+			name: "returns CR ProbeLabelSelector when self contained",
+			args: args{
+				cr: buildObservabilityCR(func(obsCR *v1.Observability) {
+					obsCR.Spec.SelfContained = &v1.SelfContained{
+						ProbeLabelSelector: labelSelectorWithNamespace,
+					}
+				}),
+				indexes: []v1.RepositoryIndex{},
+			},
+			want: labelSelectorWithNamespace,
+		},
+		{
+			name: "returns blank LabelSelector when self contained selector is nil and selectors are overridden",
+			args: args{
+				cr: buildObservabilityCR(func(obsCR *v1.Observability) {
+					obsCR.Spec.SelfContained = &v1.SelfContained{
+						RuleLabelSelector: nil,
+						OverrideSelectors: &([]bool{true})[0],
+					}
+				}),
+				indexes: []v1.RepositoryIndex{},
+			},
+			want: &v12.LabelSelector{},
+		},
+		{
+			name: "returns probe LabelSelector from repo Prometheus Index",
+			args: args{
+				cr:      buildObservabilityCR(nil),
+				indexes: testRepoIndexes,
+			},
+			want: labelSelectorWithNamespace,
+		},
+		{
+			name: "returns default probe LabelSelector when self contained is nil and no repo config",
+			args: args{
+				cr:      buildObservabilityCR(nil),
+				indexes: []v1.RepositoryIndex{},
+			},
+			want: &v12.LabelSelector{
+				MatchLabels: defaultPrometheusLabelSelectors,
+			},
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetProbeLabelSelectors(tt.args.cr, tt.args.indexes)
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestPrometheusResources_GetPrometheusPodMonitorNamespaceSelectors(t *testing.T) {
+	type args struct {
+		cr      *v1.Observability
+		indexes []v1.RepositoryIndex
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want *v12.LabelSelector
+	}{
+		{
+			name: "returns CR PodMonitorNamespaceSelector when self contained",
+			args: args{
+				cr: buildObservabilityCR(func(obsCR *v1.Observability) {
+					obsCR.Spec.SelfContained = &v1.SelfContained{
+						PodMonitorNamespaceSelector: labelSelectorWithNamespace,
+					}
+				}),
+				indexes: []v1.RepositoryIndex{},
+			},
+			want: labelSelectorWithNamespace,
+		},
+		{
+			name: "returns blank NamespaceSelector when self contained selector is nil and selectors are overridden",
+			args: args{
+				cr: buildObservabilityCR(func(obsCR *v1.Observability) {
+					obsCR.Spec.SelfContained = &v1.SelfContained{
+						PodMonitorNamespaceSelector: nil,
+						OverrideSelectors:           &([]bool{true})[0],
+					}
+				}),
+				indexes: []v1.RepositoryIndex{},
+			},
+			want: &v12.LabelSelector{},
+		},
+		{
+			name: "returns pod monitor NamespaceSelector from repo Prometheus Index",
+			args: args{
+				cr:      buildObservabilityCR(nil),
+				indexes: testRepoIndexes,
+			},
+			want: labelSelectorWithNamespace,
+		},
+		{
+			name: "returns nil when self contained is nil and no repo config",
+			args: args{
+				cr:      buildObservabilityCR(nil),
+				indexes: []v1.RepositoryIndex{},
+			},
+			want: nil,
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetPrometheusPodMonitorNamespaceSelectors(tt.args.cr, tt.args.indexes)
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestPrometheusResources_GetPrometheusServiceMonitorNamespaceSelectors(t *testing.T) {
+	type args struct {
+		cr      *v1.Observability
+		indexes []v1.RepositoryIndex
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want *v12.LabelSelector
+	}{
+		{
+			name: "returns CR ServiceMonitorNamespaceSelector when self contained",
+			args: args{
+				cr: buildObservabilityCR(func(obsCR *v1.Observability) {
+					obsCR.Spec.SelfContained = &v1.SelfContained{
+						ServiceMonitorNamespaceSelector: labelSelectorWithNamespace,
+					}
+				}),
+				indexes: []v1.RepositoryIndex{},
+			},
+			want: labelSelectorWithNamespace,
+		},
+		{
+			name: "returns blank LabelSelector when self contained selector is nil and selectors are overridden",
+			args: args{
+				cr: buildObservabilityCR(func(obsCR *v1.Observability) {
+					obsCR.Spec.SelfContained = &v1.SelfContained{
+						ServiceMonitorNamespaceSelector: nil,
+						OverrideSelectors:               &([]bool{true})[0],
+					}
+				}),
+				indexes: []v1.RepositoryIndex{},
+			},
+			want: &v12.LabelSelector{},
+		},
+		{
+			name: "returns service monitor NamespaceSelector from repo Prometheus Index",
+			args: args{
+				cr:      buildObservabilityCR(nil),
+				indexes: testRepoIndexes,
+			},
+			want: labelSelectorWithNamespace,
+		},
+		{
+			name: "returns nil when self contained is nil and no repo config",
+			args: args{
+				cr:      buildObservabilityCR(nil),
+				indexes: []v1.RepositoryIndex{},
+			},
+			want: nil,
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetPrometheusServiceMonitorNamespaceSelectors(tt.args.cr, tt.args.indexes)
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestPrometheusResources_GetPrometheusRuleNamespaceSelectors(t *testing.T) {
+	type args struct {
+		cr      *v1.Observability
+		indexes []v1.RepositoryIndex
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want *v12.LabelSelector
+	}{
+		{
+			name: "returns CR RuleNamespaceSelector when self contained",
+			args: args{
+				cr: buildObservabilityCR(func(obsCR *v1.Observability) {
+					obsCR.Spec.SelfContained = &v1.SelfContained{
+						RuleNamespaceSelector: labelSelectorWithNamespace,
+					}
+				}),
+				indexes: []v1.RepositoryIndex{},
+			},
+			want: labelSelectorWithNamespace,
+		},
+		{
+			name: "returns blank NamespaceSelector when self contained selector is nil and selectors are overridden",
+			args: args{
+				cr: buildObservabilityCR(func(obsCR *v1.Observability) {
+					obsCR.Spec.SelfContained = &v1.SelfContained{
+						RuleNamespaceSelector: nil,
+						OverrideSelectors:     &([]bool{true})[0],
+					}
+				}),
+				indexes: []v1.RepositoryIndex{},
+			},
+			want: &v12.LabelSelector{},
+		},
+		{
+			name: "returns Prometheus rule NamespaceSelector from repo Prometheus Index",
+			args: args{
+				cr: &v1.Observability{
+					Spec: v1.ObservabilitySpec{
+						SelfContained: nil,
+					},
+				},
+				indexes: testRepoIndexes,
+			},
+			want: labelSelectorWithNamespace,
+		},
+		{
+			name: "returns nil when self contained is nil and no repo config",
+			args: args{
+				cr:      buildObservabilityCR(nil),
+				indexes: []v1.RepositoryIndex{},
+			},
+			want: nil,
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetPrometheusRuleNamespaceSelectors(tt.args.cr, tt.args.indexes)
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestPrometheusResources_GetProbeNamespaceSelectors(t *testing.T) {
+	type args struct {
+		cr      *v1.Observability
+		indexes []v1.RepositoryIndex
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want *v12.LabelSelector
+	}{
+		{
+			name: "returns CR ProbeNamespaceSelector when self contained",
+			args: args{
+				cr: buildObservabilityCR(func(obsCR *v1.Observability) {
+					obsCR.Spec.SelfContained = &v1.SelfContained{
+						ProbeNamespaceSelector: labelSelectorWithNamespace,
+					}
+				}),
+				indexes: []v1.RepositoryIndex{},
+			},
+			want: labelSelectorWithNamespace,
+		},
+		{
+			name: "returns blank NamespaceSelector when self contained selector is nil and selectors are overridden",
+			args: args{
+				cr: buildObservabilityCR(func(obsCR *v1.Observability) {
+					obsCR.Spec.SelfContained = &v1.SelfContained{
+						ProbeNamespaceSelector: nil,
+						OverrideSelectors:      &([]bool{true})[0],
+					}
+				}),
+				indexes: []v1.RepositoryIndex{},
+			},
+			want: &v12.LabelSelector{},
+		},
+		{
+			name: "returns probe NamespaceSelector from repo Prometheus Index",
+			args: args{
+				cr:      buildObservabilityCR(nil),
+				indexes: testRepoIndexes,
+			},
+			want: labelSelectorWithNamespace,
+		},
+		{
+			name: "returns nil when self contained is nil and no repo config",
+			args: args{
+				cr:      buildObservabilityCR(nil),
+				indexes: []v1.RepositoryIndex{},
+			},
+			want: nil,
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetProbeNamespaceSelectors(tt.args.cr, tt.args.indexes)
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestPrometheusResources_GetPrometheusVersion(t *testing.T) {
+	type args struct {
+		cr *v1.Observability
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "returns CR PrometheusVersion when self contained",
+			args: args{
+				cr: buildObservabilityCR(func(obsCR *v1.Observability) {
+					obsCR.Spec.SelfContained = &v1.SelfContained{
+						PrometheusVersion: "test-version",
+					}
+				}),
+			},
+			want: "test-version",
+		},
+		{
+			name: "returns default Prometheus version when NOT self contained",
+			args: args{
+				cr: buildObservabilityCR(nil),
+			},
+			want: PrometheusVersion,
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetPrometheusVersion(tt.args.cr)
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestPrometheusResources_GetPrometheusResourceRequirement(t *testing.T) {
+	type args struct {
+		cr *v1.Observability
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want corev1.ResourceRequirements
+	}{
+		{
+			name: "returns CR PrometheusResourceRequirement when self contained",
+			args: args{
+				cr: buildObservabilityCR(func(obsCR *v1.Observability) {
+					obsCR.Spec.SelfContained = &v1.SelfContained{
+						PrometheusResourceRequirement: corev1.ResourceRequirements{
+							Limits: testResourceList,
+						},
+					}
+				}),
+			},
+			want: corev1.ResourceRequirements{
+				Limits: testResourceList,
+			},
+		},
+		{
+			name: "returns blank ResourceRequirements when NOT self contained",
+			args: args{
+				cr: buildObservabilityCR(nil),
+			},
+			want: corev1.ResourceRequirements{},
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetPrometheusResourceRequirement(tt.args.cr)
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestPrometheusResources_GetPrometheusOperatorResourceRequirement(t *testing.T) {
+	type args struct {
+		cr *v1.Observability
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want corev1.ResourceRequirements
+	}{
+		{
+			name: "returns CR PrometheusOperatorResourceRequirement when self contained",
+			args: args{
+				cr: buildObservabilityCR(func(obsCR *v1.Observability) {
+					obsCR.Spec.SelfContained = &v1.SelfContained{
+						PrometheusOperatorResourceRequirement: corev1.ResourceRequirements{
+							Limits: testResourceList,
+						},
+					}
+				}),
+			},
+			want: corev1.ResourceRequirements{
+				Limits: testResourceList,
+			},
+		},
+		{
+			name: "returns blank ResourceRequirements when NOT self contained",
+			args: args{
+				cr: buildObservabilityCR(nil),
+			},
+			want: corev1.ResourceRequirements{},
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetPrometheusOperatorResourceRequirement(tt.args.cr)
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestPrometheusResources_GetPrometheusStorageSize(t *testing.T) {
 	type args struct {
 		cr      *v1.Observability
 		indexes []v1.RepositoryIndex
@@ -22,85 +1318,82 @@ func TestGetPrometheusStorageSize(t *testing.T) {
 		{
 			name: "cr storage is used when selfcontained is specified AND a storage value is provided",
 			args: args{
-				cr: &v1.Observability{
-					Spec: v1.ObservabilitySpec{
-						Storage: &v1.Storage{
-							PrometheusStorageSpec: &monitoringv1.StorageSpec{
-								VolumeClaimTemplate: monitoringv1.EmbeddedPersistentVolumeClaim{
-									Spec: corev1.PersistentVolumeClaimSpec{
-										Resources: corev1.ResourceRequirements{
-											Requests: map[corev1.ResourceName]resource.Quantity{
-												corev1.ResourceStorage: resource.MustParse("10Gi"),
-											},
-										},
+				cr: buildObservabilityCR(func(obsCR *v1.Observability) {
+					obsCR.Spec.SelfContained = &v1.SelfContained{}
+					obsCR.Spec.Storage = &v1.Storage{
+						PrometheusStorageSpec: &monitoringv1.StorageSpec{
+							VolumeClaimTemplate: monitoringv1.EmbeddedPersistentVolumeClaim{
+								Spec: corev1.PersistentVolumeClaimSpec{
+									Resources: corev1.ResourceRequirements{
+										Requests: testResourceList,
 									},
 								},
 							},
 						},
-						SelfContained: &v1.SelfContained{},
-					},
-				},
+					}
+				}),
 			},
 			want: "10Gi",
 		},
+
 		{
 			name: "default storage is used when selfcontained is NOT specified AND NO storage value is provided",
 			args: args{
-				cr: &v1.Observability{
-					Spec: v1.ObservabilitySpec{},
-				},
+				cr: buildObservabilityCR(nil),
 			},
 			want: "250Gi",
 		},
 		{
 			name: "no nil failure when selfcontained is specified AND a storage value is NOT provided",
 			args: args{
-				cr: &v1.Observability{
-					Spec: v1.ObservabilitySpec{
-						SelfContained: &v1.SelfContained{},
-					},
-				},
+				cr: buildObservabilityCR(func(obsCR *v1.Observability) {
+					obsCR.Spec.SelfContained = &v1.SelfContained{}
+				}),
 			},
 			want: "250Gi",
 		},
 		{
 			name: "no nil failure when selfcontained is specified AND PersistentVolumeClaim is NOT provided",
 			args: args{
-				cr: &v1.Observability{
-					Spec: v1.ObservabilitySpec{
-						SelfContained: &v1.SelfContained{},
-						Storage: &v1.Storage{
-							PrometheusStorageSpec: &monitoringv1.StorageSpec{
-								VolumeClaimTemplate: monitoringv1.EmbeddedPersistentVolumeClaim{
-									Spec: corev1.PersistentVolumeClaimSpec{},
-								},
+				cr: buildObservabilityCR(func(obsCR *v1.Observability) {
+					obsCR.Spec.SelfContained = &v1.SelfContained{}
+					obsCR.Spec.Storage = &v1.Storage{
+						PrometheusStorageSpec: &monitoringv1.StorageSpec{
+							VolumeClaimTemplate: monitoringv1.EmbeddedPersistentVolumeClaim{
+								Spec: corev1.PersistentVolumeClaimSpec{},
 							},
 						},
-					},
-				},
+					}
+				}),
 			},
 			want: "250Gi",
 		},
 		{
 			name: "no nil failure when selfcontained is specified AND EmbeddedPersistentVolumeClaim is NOT provided",
 			args: args{
-				cr: &v1.Observability{
-					Spec: v1.ObservabilitySpec{
-						SelfContained: &v1.SelfContained{},
-						Storage: &v1.Storage{
-							PrometheusStorageSpec: &monitoringv1.StorageSpec{},
-						},
-					},
-				},
+				cr: buildObservabilityCR(func(obsCR *v1.Observability) {
+					obsCR.Spec.SelfContained = &v1.SelfContained{}
+					obsCR.Spec.Storage = &v1.Storage{
+						PrometheusStorageSpec: &monitoringv1.StorageSpec{},
+					}
+				}),
 			},
 			want: "250Gi",
 		},
+		{
+			name: "returns repo PVC override size if NOT self contained and OverridePrometheusPvcSize is not empty",
+			args: args{
+				cr:      buildObservabilityCR(nil),
+				indexes: testRepoIndexes,
+			},
+			want: "test-quantity",
+		},
 	}
+	RegisterTestingT(t)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := GetPrometheusStorageSize(tt.args.cr, tt.args.indexes); got != tt.want {
-				t.Errorf("GetPrometheusStorageSize() = %v, want %v", got, tt.want)
-			}
+			result := GetPrometheusStorageSize(tt.args.cr, tt.args.indexes)
+			Expect(result).To(Equal(tt.want))
 		})
 	}
 }

--- a/controllers/model/promtail_resource_test.go
+++ b/controllers/model/promtail_resource_test.go
@@ -1,0 +1,497 @@
+package model
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	v1 "github.com/redhat-developer/observability-operator/v3/api/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	testPromtailConfig = `
+server:
+  http_listen_port: 9080
+  http_listen_address: 0.0.0.0
+clients:
+  - url: 
+    external_labels:
+      cluster_id: "test-cluster-id"
+      observability_id: "test-observability"
+    tls_config:
+      insecure_skip_verify: true
+scrape_configs:
+  - job_name: "strimzi"
+    relabel_configs:
+    - source_labels:
+      - __meta_kubernetes_pod_node_name
+      target_label: __host__
+    - action: replace
+      source_labels:
+      - __meta_kubernetes_pod_node_name
+      target_label: nodename
+    - action: replace
+      source_labels:
+      - __meta_kubernetes_namespace
+      target_label: namespace
+    - action: replace
+      source_labels:
+      - __meta_kubernetes_pod_name
+      target_label: instance
+    - action: replace
+      source_labels:
+      - __meta_kubernetes_pod_container_name
+      target_label: container_name
+    - action: labelmap
+      regex: __meta_kubernetes_pod_label_strimzi_io_(.+)
+      replacement: strimzi_io_$1
+    - replacement: /var/log/pods/*$1/*.log
+      separator: /
+      source_labels:
+      - __meta_kubernetes_pod_uid
+      - __meta_kubernetes_pod_container_name
+      target_label: __path__
+    kubernetes_sd_configs:
+      - role: "pod"
+        namespaces:
+          names: [test1,test2]
+`
+	testPromtailConfigDex = `
+server:
+  http_listen_port: 9080
+  http_listen_address: 0.0.0.0
+clients:
+  - url: test-gateway/api/logs/v1/test-tenant/loki/api/v1/push
+    bearer_token_file: /opt/secrets/token
+    external_labels:
+      cluster_id: "test-cluster-id"
+      observability_id: "test-observability"
+    tls_config:
+      insecure_skip_verify: true
+scrape_configs:
+  - job_name: "strimzi"
+    relabel_configs:
+    - source_labels:
+      - __meta_kubernetes_pod_node_name
+      target_label: __host__
+    - action: replace
+      source_labels:
+      - __meta_kubernetes_pod_node_name
+      target_label: nodename
+    - action: replace
+      source_labels:
+      - __meta_kubernetes_namespace
+      target_label: namespace
+    - action: replace
+      source_labels:
+      - __meta_kubernetes_pod_name
+      target_label: instance
+    - action: replace
+      source_labels:
+      - __meta_kubernetes_pod_container_name
+      target_label: container_name
+    - action: labelmap
+      regex: __meta_kubernetes_pod_label_strimzi_io_(.+)
+      replacement: strimzi_io_$1
+    - replacement: /var/log/pods/*$1/*.log
+      separator: /
+      source_labels:
+      - __meta_kubernetes_pod_uid
+      - __meta_kubernetes_pod_container_name
+      target_label: __path__
+    kubernetes_sd_configs:
+      - role: "pod"
+        namespaces:
+          names: [test1,test2]
+`
+	testPromtailConfigRedHat = `
+server:
+  http_listen_port: 9080
+  http_listen_address: 0.0.0.0
+clients:
+  - url: http://token-refresher-logs-test-id.testNamespace.svc.cluster.local
+    external_labels:
+      cluster_id: "test-cluster-id"
+      observability_id: "test-observability"
+    tls_config:
+      insecure_skip_verify: true
+scrape_configs:
+  - job_name: "strimzi"
+    relabel_configs:
+    - source_labels:
+      - __meta_kubernetes_pod_node_name
+      target_label: __host__
+    - action: replace
+      source_labels:
+      - __meta_kubernetes_pod_node_name
+      target_label: nodename
+    - action: replace
+      source_labels:
+      - __meta_kubernetes_namespace
+      target_label: namespace
+    - action: replace
+      source_labels:
+      - __meta_kubernetes_pod_name
+      target_label: instance
+    - action: replace
+      source_labels:
+      - __meta_kubernetes_pod_container_name
+      target_label: container_name
+    - action: labelmap
+      regex: __meta_kubernetes_pod_label_strimzi_io_(.+)
+      replacement: strimzi_io_$1
+    - replacement: /var/log/pods/*$1/*.log
+      separator: /
+      source_labels:
+      - __meta_kubernetes_pod_uid
+      - __meta_kubernetes_pod_container_name
+      target_label: __path__
+    kubernetes_sd_configs:
+      - role: "pod"
+        namespaces:
+          names: [test1,test2]
+`
+)
+
+func TestPromtailResources_GetPromtailConfigmap(t *testing.T) {
+	type args struct {
+		cr   *v1.Observability
+		name string
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want *corev1.ConfigMap
+	}{
+		{
+			name: "return Promtail ConfigMap",
+			args: args{
+				cr:   buildObservabilityCR(nil),
+				name: "test",
+			},
+			want: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "promtail-config-test",
+					Namespace: testNamespace,
+					Labels: map[string]string{
+						"managed-by": "observability-operator",
+					},
+				},
+			},
+		},
+	}
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetPromtailConfigmap(tt.args.cr, tt.args.name)
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestPromtailResources_GetPromtailDaemonSet(t *testing.T) {
+	type args struct {
+		cr   *v1.Observability
+		name string
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want *appsv1.DaemonSet
+	}{
+		{
+			name: "return Promtail daemon set",
+			args: args{
+				cr:   buildObservabilityCR(nil),
+				name: "test",
+			},
+			want: &appsv1.DaemonSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "promtail-test",
+					Namespace: testNamespace,
+					Labels: map[string]string{
+						"managed-by": "observability-operator",
+					},
+				},
+			},
+		},
+	}
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetPromtailDaemonSet(tt.args.cr, tt.args.name)
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestPromtailResources_GetPromtailServiceAccount(t *testing.T) {
+	type args struct {
+		cr *v1.Observability
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want *corev1.ServiceAccount
+	}{
+		{
+			name: "return Promtail service account",
+			args: args{
+				cr: buildObservabilityCR(nil),
+			},
+			want: &corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kafka-promtail",
+					Namespace: testNamespace,
+				},
+			},
+		},
+	}
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetPromtailServiceAccount(tt.args.cr)
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestPromtailResources_GetPromtailClusterRole(t *testing.T) {
+	type args struct {
+		cr *v1.Observability
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want *rbacv1.ClusterRole
+	}{
+		{
+			name: "return Promtail cluster role",
+			args: args{
+				cr: buildObservabilityCR(nil),
+			},
+			want: &rbacv1.ClusterRole{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "kafka-promtail",
+				},
+			},
+		},
+	}
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetPromtailClusterRole(tt.args.cr)
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestPromtailResources_GetPromtailClusterRoleBinding(t *testing.T) {
+	type args struct {
+		cr *v1.Observability
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want *rbacv1.ClusterRoleBinding
+	}{
+		{
+			name: "return Promtail cluster role binding",
+			args: args{
+				cr: buildObservabilityCR(nil),
+			},
+			want: &rbacv1.ClusterRoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "kafka-promtail",
+				},
+			},
+		},
+	}
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetPromtailClusterRoleBinding(tt.args.cr)
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestPromtailResources_GetPromtailConfig(t *testing.T) {
+	type args struct {
+		cr         *v1.Observability
+		c          *v1.ObservatoriumIndex
+		indexId    string
+		namespaces []string
+	}
+
+	type wantErr struct {
+		exists bool
+		msg    string
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr wantErr
+	}{
+		{
+			name: "return Promtail config when auth type is red hat",
+			args: args{
+				cr: buildObservabilityCR(func(obsCR *v1.Observability) {
+					obsCR.Status.ClusterID = "test-cluster-id"
+				}),
+				c: &v1.ObservatoriumIndex{
+					Id:       "test-id",
+					Gateway:  "test-gateway",
+					Tenant:   "test-tenant",
+					AuthType: v1.AuthTypeRedhat,
+					RedhatSsoConfig: &v1.RedhatSsoConfig{
+						Url:        "test-url",
+						Realm:      "test-realm",
+						LogsSecret: "test-logs-secret",
+						LogsClient: "test-logs-client",
+					},
+				},
+				indexId:    "test-observability",
+				namespaces: testPattern,
+			},
+			want: testPromtailConfigRedHat,
+		},
+		{
+			name: "return Promtail config when no Observatorium index",
+			args: args{
+				cr: buildObservabilityCR(func(obsCR *v1.Observability) {
+					obsCR.Status.ClusterID = "test-cluster-id"
+				}),
+				c:          nil,
+				indexId:    "test-observability",
+				namespaces: testPattern,
+			},
+			want: testPromtailConfig,
+		},
+		{
+			name: "return Promtail config when auth type is dex",
+			args: args{
+				cr: buildObservabilityCR(func(obsCR *v1.Observability) {
+					obsCR.Status.ClusterID = "test-cluster-id"
+				}),
+				c: &v1.ObservatoriumIndex{
+					Id:       "test-id",
+					Gateway:  "test-gateway",
+					Tenant:   "test-tenant",
+					AuthType: v1.AuthTypeDex,
+				},
+				indexId:    "test-observability",
+				namespaces: testPattern,
+			},
+			want: testPromtailConfigDex,
+		},
+
+		{
+			name: "error when Observatorium index is not valid",
+			args: args{
+				cr: buildObservabilityCR(func(obsCR *v1.Observability) {
+					obsCR.Status.ClusterID = "test-cluster-id"
+				}),
+				c: &v1.ObservatoriumIndex{
+					Id:      "test-id",
+					Gateway: "",
+					Tenant:  "",
+				},
+				indexId:    "test-observability",
+				namespaces: testPattern,
+			},
+			want: "",
+			wantErr: wantErr{
+				exists: true,
+				msg:    "invalid observatorium config for test-id",
+			},
+		},
+		{
+			name: "error when authtype is Red Hat SSO but config is nil",
+			args: args{
+				cr: buildObservabilityCR(func(obsCR *v1.Observability) {
+					obsCR.Status.ClusterID = "test-cluster-id"
+				}),
+				c: &v1.ObservatoriumIndex{
+					Id:              "test-id",
+					Gateway:         "test-gateway",
+					Tenant:          "test-tenant",
+					AuthType:        v1.AuthTypeRedhat,
+					RedhatSsoConfig: nil,
+				},
+				indexId:    "test-observability",
+				namespaces: testPattern,
+			},
+			want: "",
+			wantErr: wantErr{
+				exists: true,
+				msg:    "invalid sso config for test-id",
+			},
+		},
+	}
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := GetPromtailConfig(tt.args.cr, tt.args.c, tt.args.indexId, tt.args.namespaces)
+			Expect(err != nil).To(Equal(tt.wantErr.exists))
+			if err != nil {
+				Expect(err.Error()).To(Equal(tt.wantErr.msg))
+			}
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestPromtailResources_GetPromtailDaemonSetLabels(t *testing.T) {
+	type args struct {
+		index *v1.RepositoryIndex
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want *metav1.LabelSelector
+	}{
+		{
+			name: "return DaemonSetLabelSelector from index",
+			args: args{
+				index: &testRepoIndexes[1],
+			},
+			want: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "promtail-test",
+				},
+			},
+		},
+		{
+			name: "return DaemonSetLabelSelector from index",
+			args: args{
+				index: &v1.RepositoryIndex{
+					Config: nil,
+				},
+			},
+			want: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "promtail",
+				},
+			},
+		},
+	}
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetPromtailDaemonSetLabels(tt.args.index)
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}

--- a/controllers/model/token_refresher_resources_test.go
+++ b/controllers/model/token_refresher_resources_test.go
@@ -1,0 +1,143 @@
+package model
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	v1 "github.com/redhat-developer/observability-operator/v3/api/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	v14 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestTokenRefresherResources_GetTokenRefresherName(t *testing.T) {
+	type args struct {
+		id string
+		t  TokenRefresherType
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "return default token refresher name",
+			args: args{
+				id: "test-id",
+				t:  "test-token-refresher-type",
+			},
+			want: "token-refresher-test-token-refresher-type-test-id",
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetTokenRefresherName(tt.args.id, tt.args.t)
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestTokenRefresherResources_GetTokenRefresherService(t *testing.T) {
+	type args struct {
+		cr   *v1.Observability
+		name string
+	}
+	tests := []struct {
+		name string
+		args args
+		want *corev1.Service
+	}{
+		{
+			name: "return token refresher service",
+			args: args{
+				cr:   buildObservabilityCR(nil),
+				name: "test-service-name",
+			},
+			want: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-service-name",
+					Namespace: testNamespace,
+				},
+			},
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetTokenRefresherService(tt.args.cr, tt.args.name)
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestTokenRefresherResources_GetTokenRefresherDeployment(t *testing.T) {
+	type args struct {
+		cr   *v1.Observability
+		name string
+	}
+	tests := []struct {
+		name string
+		args args
+		want *appsv1.Deployment
+	}{
+		{
+			name: "return token refresher deployment",
+			args: args{
+				cr:   buildObservabilityCR(nil),
+				name: "test-deployment-name",
+			},
+			want: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-deployment-name",
+					Namespace: testNamespace,
+				},
+			},
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetTokenRefresherDeployment(tt.args.cr, tt.args.name)
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestTokenRefresherResources_GetTokenRefresherNetworkPolicy(t *testing.T) {
+	type args struct {
+		cr   *v1.Observability
+		name string
+	}
+	tests := []struct {
+		name string
+		args args
+		want *v14.NetworkPolicy
+	}{
+		{
+			name: "return token refresher network policy",
+			args: args{
+				cr:   buildObservabilityCR(nil),
+				name: "test-name",
+			},
+			want: &v14.NetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-name-network-policy",
+					Namespace: testNamespace,
+				},
+			},
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetTokenRefresherNetworkPolicy(tt.args.cr, tt.args.name)
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}

--- a/controllers/model/token_resources_test.go
+++ b/controllers/model/token_resources_test.go
@@ -1,0 +1,48 @@
+package model
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	v1 "github.com/redhat-developer/observability-operator/v3/api/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestTokenResources_GetTokenSecret(t *testing.T) {
+	type args struct {
+		cr   *v1.Observability
+		name string
+	}
+	tests := []struct {
+		name string
+		args args
+		want *corev1.Secret
+	}{
+		{
+			name: "return cr AlertManagerDefaultName if self contained",
+			args: args{
+				cr:   buildObservabilityCR(nil),
+				name: "test-secret-name",
+			},
+			want: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-secret-name",
+					Namespace: testNamespace,
+					Labels: map[string]string{
+						"managed-by": "observability-operator",
+						"purpose":    "observatorium-token-secret",
+					},
+				},
+			},
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetTokenSecret(tt.args.cr, tt.args.name)
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}

--- a/controllers/observability_controller.go
+++ b/controllers/observability_controller.go
@@ -352,20 +352,6 @@ func observabilityInstanceWithStorage(namespace string) apiv1.Observability {
 						},
 					},
 				},
-				AlertManagerStorageSpec: &prometheusv1.StorageSpec{
-					VolumeClaimTemplate: prometheusv1.EmbeddedPersistentVolumeClaim{
-						EmbeddedObjectMetadata: prometheusv1.EmbeddedObjectMetadata{
-							Name: "managed-services",
-						},
-						Spec: v1.PersistentVolumeClaimSpec{
-							Resources: v1.ResourceRequirements{
-								Requests: map[v1.ResourceName]resource.Quantity{
-									v1.ResourceStorage: resource.MustParse(model.AlertManagerDefaultStorage),
-								},
-							},
-						},
-					},
-				},
 			},
 			SelfContained: &apiv1.SelfContained{
 				DisableBlackboxExporter: &([]bool{true})[0],


### PR DESCRIPTION
## Description
Jira: [MGDSTRM-8329](https://issues.redhat.com/browse/MGDSTRM-8329)

This change increases testing coverage of controllers/model package. 

| | Current testing coverage | Coverage with this change |
| --- | --- | --- |
| controllers/model/alertmanager_resources.go | 0.0% | 100.0% |
| controllers/model/grafana_resources.go | 0.0% | 100.0% |
| controllers/model/prometheus_resources.go | 6.1% | 83.2% |
| controllers/model/promtail_resources.go | 0.0% | 100% |
| controllers/model/token_refresher_resources.go | 0.0% | 100% |
| controllers/model/token_resources.go | 0.0% | 100% |
| **Overall** | **3.8%** | **90.1%** |

Also includes updates to remove AlertManagerStorageSpec from default Observability and remove default value for AlertManagerDefaultStorage. Verified that CR value for alert manager storage is applied when included in custom CR.

## Verification

- On `main` run `make test/unit`. Output should contain testing coverage for controllers/model/
  - For example: 
    - `ok   github.com/redhat-developer/observability-operator/v3/controllers/model/    0.010s  coverage: 3.8% of statements`
    
- On this PR run `make test/unit PKG=controllers/model/`. Output should contain testing coverage for controllers/model
  - For example: 
    - `ok   github.com/redhat-developer/observability-operator/v3/controllers/model/    0.011s  coverage: 90.1% of statements`
- Run `make test/coverage/output` to display breakdown of testing coverage (excluding generated files) with a final total value of 90.1%
