### PR TITLE
test: add tests to controllers/reconcilers/token

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,7 @@ test/unit: generate fmt vet manifests
 	-e "github.com/redhat-developer/observability-operator/v3/controllers/reconcilers/configuration/configuration_reconciler.go" \
 	-e "github.com/redhat-developer/observability-operator/v3/controllers/reconcilers/configuration/grafana.go" \
 	-e "github.com/redhat-developer/observability-operator/v3/controllers/reconcilers/configuration/promtail.go" \
+	-e "github.com/redhat-developer/observability-operator/v3/controllers/reconcilers/token/token_reconciler.go" \
 	cover.out.tmp > cover.out
 	rm cover.out.tmp
 

--- a/controllers/reconcilers/token/token_manager_test.go
+++ b/controllers/reconcilers/token/token_manager_test.go
@@ -1,0 +1,131 @@
+package token
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	v1 "github.com/redhat-developer/observability-operator/v3/api/v1"
+)
+
+func TestTokenManager_GetObservatoriumTokenSecretName(t *testing.T) {
+	g := NewWithT(t)
+	config := &v1.ObservatoriumIndex{
+		Id: "test-id",
+	}
+
+	result := GetObservatoriumTokenSecretName(config)
+	g.Expect(result).To(Equal("obs-token-test-id"))
+}
+
+func TestTokenManager_GetObservatoriumPrometheusSecretName(t *testing.T) {
+	g := NewWithT(t)
+	index := &v1.RepositoryIndex{
+		Id: "test-id",
+		Config: &v1.RepositoryConfig{
+			Prometheus: &v1.PrometheusIndex{
+				Observatorium: "test-observatorium",
+			},
+			Observatoria: []v1.ObservatoriumIndex{
+				{
+					Id: "test-observatorium",
+				},
+			},
+		},
+	}
+
+	result := GetObservatoriumPrometheusSecretName(index)
+	g.Expect(result).To(Equal("obs-token-test-observatorium"))
+}
+
+func TestTokenManager_GetObservatoriumPromtailSecretName(t *testing.T) {
+	g := NewWithT(t)
+	index := &v1.RepositoryIndex{
+		Id: "test-id",
+		Config: &v1.RepositoryConfig{
+			Promtail: &v1.PromtailIndex{
+				Observatorium: "test-observatorium",
+			},
+			Observatoria: []v1.ObservatoriumIndex{
+				{
+					Id: "test-observatorium",
+				},
+			},
+		},
+	}
+
+	result := GetObservatoriumPromtailSecretName(index)
+	g.Expect(result).To(Equal("obs-token-test-observatorium"))
+}
+
+func TestTokenManager_GetObservatoriumConfig(t *testing.T) {
+	type args struct {
+		index *v1.RepositoryIndex
+		id    string
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want *v1.ObservatoriumIndex
+	}{
+		{
+			name: "returns ObservatoriumIndex with id matching input id",
+			args: args{
+				index: &v1.RepositoryIndex{
+					Id: "test-id",
+					Config: &v1.RepositoryConfig{
+						Promtail: &v1.PromtailIndex{
+							Observatorium: "test-observatorium",
+						},
+						Observatoria: []v1.ObservatoriumIndex{
+							{
+								Id: "test-observatorium",
+							},
+						},
+					},
+				},
+				id: "test-observatorium",
+			},
+			want: &v1.ObservatoriumIndex{
+				Id: "test-observatorium",
+			},
+		},
+		{
+			name: "returns nil if repo index is nil",
+			args: args{
+				index: nil,
+				id:    "test-observatorium",
+			},
+			want: nil,
+		},
+		{
+			name: "returns nil if observatorium id does NOT match input id",
+			args: args{
+				index: &v1.RepositoryIndex{
+					Id: "test-id",
+					Config: &v1.RepositoryConfig{
+						Promtail: &v1.PromtailIndex{
+							Observatorium: "test-observatorium",
+						},
+						Observatoria: []v1.ObservatoriumIndex{
+							{
+								Id: "test-observatorium",
+							},
+						},
+					},
+				},
+				id: "does-not-match",
+			},
+			want: nil,
+		},
+	}
+
+	g := NewWithT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetObservatoriumConfig(tt.args.index, tt.args.id)
+			g.Expect(result).To(Equal(tt.want))
+		})
+	}
+
+}


### PR DESCRIPTION
Jira [MGDSTRM-8339](https://issues.redhat.com/browse/MGDSTRM-8339)
This change increases testing coverage of controllers/reconcilers/token package. 

| | Current testing coverage | Coverage with this change |
| --- | --- | --- |
| controllers/reconcilers/configuration/token/token_manager.go | 0.0% | 9.2% |
| controllers/reconcilers/configuration/token/token_reconciler.go | 0.0% | ignored |
| **Overall** | **0.0%** | **9.7%** |

## Verification

- On `main` run `make test/unit`. Output should show that this package currently has no testing files
  - For example: 
    - `?   github.com/redhat-developer/observability-operator/v3/controllers/reconcilers/token    [no test files]`
    
- On this PR run `make test/unit PKG=controllers/reconcilers/token`. Output should contain testing coverage for controllers/reconcilers/token
  - For example: 
    - `ok      github.com/redhat-developer/observability-operator/v3/controllers/reconcilers/token     0.008s  coverage: 9.2% of statements`
- Run `make test/coverage/output` to display breakdown of testing coverage (excluding generated and untestable files) with a final total value of 9.7%
- **NOTE** The testing coverage is low for this package due to the use of Kubernetes clients in many of the methods. Testing of these methods will be completed by integration testing. 