### PR TITLE
Use generic default names instead of opinionated ones.

### DIFF
--- a/api/v1/observability_webhook.go
+++ b/api/v1/observability_webhook.go
@@ -90,7 +90,7 @@ func (in *Observability) ValidateUpdate(old runtime.Object) error {
 	if oldObsSpec.GrafanaDefaultName == "" &&
 		newObsSpec.GrafanaDefaultName != "" &&
 		// Special case: Allow updates iff the deprecated default name is used.
-		strings.Compare(newObsSpec.AlertManagerDefaultName, "kafka-grafana") != 0 {
+		strings.Compare(newObsSpec.GrafanaDefaultName, "kafka-grafana") != 0 {
 		return errors.New("cannot set GrafanaDefaultName after cr creation")
 	}
 
@@ -109,7 +109,7 @@ func (in *Observability) ValidateUpdate(old runtime.Object) error {
 	if oldObsSpec.PrometheusDefaultName == "" &&
 		newObsSpec.PrometheusDefaultName != "" &&
 		// Special case: Allow updates if, and only if, the deprecated default name is used.
-		strings.Compare(newObsSpec.AlertManagerDefaultName, "kafka-prometheus") != 0 {
+		strings.Compare(newObsSpec.PrometheusDefaultName, "kafka-prometheus") != 0 {
 		return errors.New("cannot set PrometheusDefaultName after cr creation")
 	}
 

--- a/api/v1/observability_webhook.go
+++ b/api/v1/observability_webhook.go
@@ -70,7 +70,7 @@ func (in *Observability) ValidateUpdate(old runtime.Object) error {
 
 	if oldObsSpec.AlertManagerDefaultName == "" &&
 		newObsSpec.AlertManagerDefaultName != "" &&
-		// Special case: Allow updates iff the deprecated default name is used.
+		// Special case: Allow updates if, and only if, the deprecated default name is used.
 		strings.Compare(newObsSpec.AlertManagerDefaultName, "kafka-alertmanager") != 0 {
 		return errors.New("cannot set AlertManagerDefaultName after cr creation")
 	}
@@ -108,7 +108,7 @@ func (in *Observability) ValidateUpdate(old runtime.Object) error {
 
 	if oldObsSpec.PrometheusDefaultName == "" &&
 		newObsSpec.PrometheusDefaultName != "" &&
-		// Special case: Allow updates iff the deprecated default name is used.
+		// Special case: Allow updates if, and only if, the deprecated default name is used.
 		strings.Compare(newObsSpec.AlertManagerDefaultName, "kafka-prometheus") != 0 {
 		return errors.New("cannot set PrometheusDefaultName after cr creation")
 	}

--- a/api/v1/observability_webhook.go
+++ b/api/v1/observability_webhook.go
@@ -53,11 +53,11 @@ func (in *Observability) ValidateCreate() error {
 func (in *Observability) ValidateUpdate(old runtime.Object) error {
 	observabilitylog.Info("validate update", "name", in.Name)
 
-	// For each value the following cannot be done
-	// unset it if it's already present
-	//	// set it if it's not set - the default kafka entry is already used
-	//	// change it if it's set already
-	// cannot remove the self contained block if it contained the value
+	// For each value the following cannot be done:
+	// 	- unset it if it's already present
+	//	- set it if it's not set - unless deprecated default names are used.
+	//    This is done within the initialization to keep backwards compatability.
+	//	- change it if it's set already
 
 	oldObsSpec := &old.(*Observability).Spec
 	newObsSpec := &in.Spec
@@ -69,7 +69,9 @@ func (in *Observability) ValidateUpdate(old runtime.Object) error {
 	}
 
 	if oldObsSpec.AlertManagerDefaultName == "" &&
-		newObsSpec.AlertManagerDefaultName != "" {
+		newObsSpec.AlertManagerDefaultName != "" &&
+		// Special case: Allow updates iff the deprecated default name is used.
+		strings.Compare(newObsSpec.AlertManagerDefaultName, "kafka-alertmanager") != 0 {
 		return errors.New("cannot set AlertManagerDefaultName after cr creation")
 	}
 
@@ -86,7 +88,9 @@ func (in *Observability) ValidateUpdate(old runtime.Object) error {
 	}
 
 	if oldObsSpec.GrafanaDefaultName == "" &&
-		newObsSpec.GrafanaDefaultName != "" {
+		newObsSpec.GrafanaDefaultName != "" &&
+		// Special case: Allow updates iff the deprecated default name is used.
+		strings.Compare(newObsSpec.AlertManagerDefaultName, "kafka-grafana") != 0 {
 		return errors.New("cannot set GrafanaDefaultName after cr creation")
 	}
 
@@ -103,7 +107,9 @@ func (in *Observability) ValidateUpdate(old runtime.Object) error {
 	}
 
 	if oldObsSpec.PrometheusDefaultName == "" &&
-		newObsSpec.PrometheusDefaultName != "" {
+		newObsSpec.PrometheusDefaultName != "" &&
+		// Special case: Allow updates iff the deprecated default name is used.
+		strings.Compare(newObsSpec.AlertManagerDefaultName, "kafka-prometheus") != 0 {
 		return errors.New("cannot set PrometheusDefaultName after cr creation")
 	}
 

--- a/controllers/model/alertmanager_resources.go
+++ b/controllers/model/alertmanager_resources.go
@@ -10,15 +10,20 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	DefaultAlertManagerName      = "observability-alertmanager"
+	DefaultKafkaAlertManagerName = "kafka-alertmanager"
+)
+
 func GetDefaultNameAlertmanager(cr *v1.Observability) string {
 	if cr.Spec.SelfContained != nil && cr.Spec.AlertManagerDefaultName != "" {
 		return cr.Spec.AlertManagerDefaultName
 	}
-	return "observability-alertmanager"
+	return DefaultAlertManagerName
 }
 
 func MigrateAlertManagerDefaults(cr *v1.Observability) {
-	cr.Spec.AlertManagerDefaultName = "kafka-alertmanager"
+	cr.Spec.AlertManagerDefaultName = DefaultKafkaAlertManagerName
 }
 
 func GetAlertmanagerProxySecret(cr *v1.Observability) *v13.Secret {

--- a/controllers/model/alertmanager_resources.go
+++ b/controllers/model/alertmanager_resources.go
@@ -14,7 +14,11 @@ func GetDefaultNameAlertmanager(cr *v1.Observability) string {
 	if cr.Spec.SelfContained != nil && cr.Spec.AlertManagerDefaultName != "" {
 		return cr.Spec.AlertManagerDefaultName
 	}
-	return "kafka-alertmanager"
+	return "observability-alertmanager"
+}
+
+func MigrateAlertManagerDefaults(cr *v1.Observability) {
+	cr.Spec.AlertManagerDefaultName = "kafka-alertmanager"
 }
 
 func GetAlertmanagerProxySecret(cr *v1.Observability) *v13.Secret {

--- a/controllers/model/grafana_resources.go
+++ b/controllers/model/grafana_resources.go
@@ -10,13 +10,18 @@ import (
 	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var defaultGrafanaLabelSelectors = map[string]string{"app": "strimzi"}
-
 func GetDefaultNameGrafana(cr *v1.Observability) string {
 	if cr.Spec.SelfContained != nil && cr.Spec.GrafanaDefaultName != "" {
 		return cr.Spec.GrafanaDefaultName
 	}
-	return "kafka-grafana"
+	return "observability-grafana"
+}
+
+func MigrateGrafanaDefaults(cr *v1.Observability) {
+	cr.Spec.GrafanaDefaultName = "kafka-grafana"
+	if cr.Spec.SelfContained != nil && cr.Spec.SelfContained.GrafanaDashboardLabelSelector == nil {
+		cr.Spec.SelfContained.GrafanaDashboardLabelSelector = &v12.LabelSelector{MatchLabels: map[string]string{"app": "strimzi"}}
+	}
 }
 
 func GetGrafanaCatalogSource(cr *v1.Observability) *v1alpha1.CatalogSource {

--- a/controllers/model/grafana_resources.go
+++ b/controllers/model/grafana_resources.go
@@ -10,15 +10,20 @@ import (
 	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	DefaultGrafanaName      = "observability-grafana"
+	DefaultKafkaGrafanaName = "kafka-grafana"
+)
+
 func GetDefaultNameGrafana(cr *v1.Observability) string {
 	if cr.Spec.SelfContained != nil && cr.Spec.GrafanaDefaultName != "" {
 		return cr.Spec.GrafanaDefaultName
 	}
-	return "observability-grafana"
+	return DefaultGrafanaName
 }
 
 func MigrateGrafanaDefaults(cr *v1.Observability) {
-	cr.Spec.GrafanaDefaultName = "kafka-grafana"
+	cr.Spec.GrafanaDefaultName = DefaultKafkaGrafanaName
 	if cr.Spec.SelfContained != nil && cr.Spec.SelfContained.GrafanaDashboardLabelSelector == nil {
 		cr.Spec.SelfContained.GrafanaDashboardLabelSelector = &v12.LabelSelector{MatchLabels: map[string]string{"app": "strimzi"}}
 	}

--- a/controllers/model/prometheus_resources.go
+++ b/controllers/model/prometheus_resources.go
@@ -22,7 +22,7 @@ import (
 	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var defaultPrometheusLabelSelectors = map[string]string{"app": "strimzi"}
+var defaultPrometheusLabelSelectors = map[string]string{"app": "observability"}
 
 const (
 	PrometheusVersion        = "v2.22.2"
@@ -33,7 +33,28 @@ func GetDefaultNamePrometheus(cr *v1.Observability) string {
 	if cr.Spec.SelfContained != nil && cr.Spec.PrometheusDefaultName != "" {
 		return cr.Spec.PrometheusDefaultName
 	}
-	return "kafka-prometheus"
+	return "observability-prometheus"
+}
+
+func MigratePrometheusDefaults(cr *v1.Observability) {
+	cr.Spec.PrometheusDefaultName = "kafka-prometheus"
+	oldDefaultLabelSelector := &v12.LabelSelector{MatchLabels: map[string]string{"app": "strimzi"}}
+	if cr.Spec.SelfContained == nil {
+		return
+	}
+
+	if cr.Spec.SelfContained.ProbeLabelSelector == nil {
+		cr.Spec.SelfContained.ProbeLabelSelector = oldDefaultLabelSelector
+	}
+	if cr.Spec.SelfContained.PodMonitorLabelSelector == nil {
+		cr.Spec.SelfContained.PodMonitorLabelSelector = oldDefaultLabelSelector
+	}
+	if cr.Spec.SelfContained.RuleLabelSelector == nil {
+		cr.Spec.SelfContained.RuleLabelSelector = oldDefaultLabelSelector
+	}
+	if cr.Spec.SelfContained.ServiceMonitorLabelSelector == nil {
+		cr.Spec.SelfContained.ServiceMonitorLabelSelector = oldDefaultLabelSelector
+	}
 }
 
 func GetPrometheusAuthTokenLifetimes(cr *v1.Observability) *v13.ConfigMap {

--- a/controllers/model/prometheus_resources.go
+++ b/controllers/model/prometheus_resources.go
@@ -25,19 +25,21 @@ import (
 var defaultPrometheusLabelSelectors = map[string]string{"app": "observability"}
 
 const (
-	PrometheusVersion        = "v2.22.2"
-	PrometheusDefaultStorage = "250Gi"
+	PrometheusVersion          = "v2.22.2"
+	PrometheusDefaultStorage   = "250Gi"
+	DefaultPrometheusName      = "observability-prometheus"
+	DefaultKafkaPrometheusName = "kafka-prometheus"
 )
 
 func GetDefaultNamePrometheus(cr *v1.Observability) string {
 	if cr.Spec.SelfContained != nil && cr.Spec.PrometheusDefaultName != "" {
 		return cr.Spec.PrometheusDefaultName
 	}
-	return "observability-prometheus"
+	return DefaultPrometheusName
 }
 
 func MigratePrometheusDefaults(cr *v1.Observability) {
-	cr.Spec.PrometheusDefaultName = "kafka-prometheus"
+	cr.Spec.PrometheusDefaultName = DefaultKafkaPrometheusName
 	oldDefaultLabelSelector := &v12.LabelSelector{MatchLabels: map[string]string{"app": "strimzi"}}
 	if cr.Spec.SelfContained == nil {
 		return


### PR DESCRIPTION
## Description

When installing the observability operator, by default a `Observability` is created. This will include default settings.

Currently, the default settings will include the following, opinionated names:
- AlertManager will be named `kafka-alertmanager`.
- Grafana will be named `kafka-grafana`.
- Prometheus will be named `kafka-prometheus`.
- As label selectors, `app: strimzi` will be required.

It's especially unfortunate that these names are leaking also into customer configuration repositories (i.e. the label selectors).
Since the observability operator should be a generic one, we should strive to use generic names for these resources as label selectors.
For this, mostly all (will be tracking this in the follow-ups further below) resource and label selector names have been renamed from `kafka-xxx` to `observability-xxx`. This will work just fine for newly created `Observabilities`, but will impose a required migration for existing `Observabilities`, which created resources using the old default names.

To overcome this, the following has been introduced within this PR:
- Renaming default names.
- During initialization, check whether the resource (grafana, prometheus, alertmanager) is found with the existing configuration (taking the new default name into account). If it is not found _and_ is found with the old name, use the CR settings to override default names and set the values to the old default names.
- Within the validation webhook, allow updating the CR, iff the old default name is used.

What will be done in a follow-up PR:
- The promtail names are still opinionated. If we can agree on the migration, they would need a `defaultPromtailName` setting within the CR, this should be done in a separate PR as to not increase the scope of this one.

## Testing

Testing has been done manually as of now, I'm happy to add more automated tests either in this PR or a follow-up.
1. Create a new CR with updated default names - ensure the new default names are used and the application is working as intended.
2. Create a CR with old default names - after switching to the new operator version, ensure that reconciliation is successful and the CR is updated accordingly.
3. Create a CR with old default names - switch to a new operator version using updated default names - ensure deletion is successful and no dangling resources can be found.