### PR TITLE
test: add tests to controllers/utils

### DIFF
--- a/controllers/reconcilers/configuration/prometheus.go
+++ b/controllers/reconcilers/configuration/prometheus.go
@@ -132,7 +132,7 @@ func (r *Reconciler) getOpenshiftMonitoringCredentials(ctx context.Context) (str
 		return "", "", err
 	}
 	//this checks if Openshift 4.10+ is present as grafana-datasources secret data in v4.10+ has different structure to previous versions
-	isDatasourceV2, err = utils.HasNewerOrSameClusterVersion(currentOSVersionString, OpenshiftVersionToCompare)
+	isDatasourceV2, err = utils.HasNewerOrSameClusterMinorVersion(currentOSVersionString, OpenshiftVersionToCompare)
 	if err != nil {
 		return "", "", err
 	}

--- a/controllers/utils/reconciler_utils.go
+++ b/controllers/utils/reconciler_utils.go
@@ -43,7 +43,7 @@ func GetClusterOSVersion(ctx context.Context, client k8sclient.Client) (string, 
 }
 
 //returns true if test cluster version string is same or newer than compareTo version string
-func HasNewerOrSameClusterVersion(test string, compareTo string) (bool, error) {
+func HasNewerOrSameClusterMinorVersion(test string, compareTo string) (bool, error) {
 	var testVersion semver.Version
 	compareToVersion, err := semver.Make(compareTo)
 	if err != nil {

--- a/controllers/utils/reconciler_utils_test.go
+++ b/controllers/utils/reconciler_utils_test.go
@@ -1,0 +1,162 @@
+package utils
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	routev1 "github.com/openshift/api/route/v1"
+	v1 "k8s.io/api/core/v1"
+)
+
+const (
+	ValidVersionString   = "3.1.10"
+	InvalidVersionString = "invalid"
+)
+
+func TestReconcilerUtils_HasNewerOrSameClusterVersion(t *testing.T) {
+	type args struct {
+		test      string
+		compareTo string
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		want    bool
+		wantErr bool
+	}{
+		{
+			name: "error when compareTo is NOT valid version",
+			args: args{
+				test:      ValidVersionString,
+				compareTo: InvalidVersionString,
+			},
+			wantErr: true,
+		},
+		{
+			name: "error when test is NOT valid version",
+			args: args{
+				test:      InvalidVersionString,
+				compareTo: ValidVersionString,
+			},
+			wantErr: true,
+		},
+		{
+			name: "return true when test version major is greater than compareTo version major",
+			args: args{
+				test:      "4.0.0",
+				compareTo: ValidVersionString,
+			},
+			want: true,
+		},
+		{
+			name: "return true when test version minor is greater than or equal to compareTo version minor",
+			args: args{
+				test:      "3.1.5",
+				compareTo: ValidVersionString,
+			},
+			want: true,
+		},
+		{
+			name: "return false when test version minor is less than compareTo version minor",
+			args: args{
+				test:      "3.0.5",
+				compareTo: ValidVersionString,
+			},
+		},
+	}
+
+	g := NewWithT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := HasNewerOrSameClusterMinorVersion(tt.args.test, tt.args.compareTo)
+			g.Expect(err != nil).To(Equal(tt.wantErr))
+			g.Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestReconcilerUtils_IsRouteReady(t *testing.T) {
+	type args struct {
+		route *routev1.Route
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "return false if route is nil",
+			args: args{
+				route: nil,
+			},
+		},
+		{
+			name: "return false if admitted route condition status is false",
+			args: args{
+				route: &routev1.Route{
+					Status: routev1.RouteStatus{
+						Ingress: []routev1.RouteIngress{
+							{
+								Conditions: []routev1.RouteIngressCondition{
+									{
+										Type:   routev1.RouteAdmitted,
+										Status: v1.ConditionFalse,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "return false if admitted route condition status is unknown",
+			args: args{
+				route: &routev1.Route{
+					Status: routev1.RouteStatus{
+						Ingress: []routev1.RouteIngress{
+							{
+								Conditions: []routev1.RouteIngressCondition{
+									{
+										Type:   routev1.RouteAdmitted,
+										Status: v1.ConditionUnknown,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "return true if admitted route condition status is true",
+			args: args{
+				route: &routev1.Route{
+					Status: routev1.RouteStatus{
+						Ingress: []routev1.RouteIngress{
+							{
+								Conditions: []routev1.RouteIngressCondition{
+									{
+										Type:   routev1.RouteAdmitted,
+										Status: v1.ConditionTrue,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+	}
+
+	g := NewWithT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsRouteReady(tt.args.route)
+			g.Expect(result).To(Equal(tt.want))
+		})
+	}
+}


### PR DESCRIPTION
Jira [MGDSTRM-8341](https://issues.redhat.com/browse/MGDSTRM-8341)
This change increases testing coverage of controllers/utils package. 

| | Current testing coverage | Coverage with this change |
| --- | --- | --- |
| controllers/utils/reconciler_utils.go | 0.0% | 39.6% |
| **Overall** | **0.0%** | **39.6%** |

## Verification

- On `main` run `make test/unit`. Output should show that this package currently has no testing files
  - For example: 
    - `?   github.com/redhat-developer/observability-operator/v3/controllers/utils    [no test files]`
    
- On this PR run `make test/unit PKG=controllers/utils`. Output should contain testing coverage for controllers/reconcilers/token
  - For example: 
    - `ok      github.com/redhat-developer/observability-operator/v3/controllers/reconcilers/token     0.008s  coverage: 39.6% of statements`
- Run `make test/coverage/output` to display breakdown of testing coverage (excluding generated and untestable files) with a final total value of 39.6%
- **NOTE** The testing coverage is low for this package due to the use of Kubernetes clients in many of the methods. Testing of these methods will be completed by integration testing. 