### PR TITLE
test: ignore untestable files from unit test coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,19 @@ test/unit: generate fmt vet manifests
 	-e "github.com/redhat-developer/observability-operator/v3/controllers/reconcilers/configuration/grafana.go" \
 	-e "github.com/redhat-developer/observability-operator/v3/controllers/reconcilers/configuration/promtail.go" \
 	-e "github.com/redhat-developer/observability-operator/v3/controllers/reconcilers/token/token_reconciler.go" \
+	-e "github.com/redhat-developer/observability-operator/v3/controllers/reconcilers/alertmanager_installation/" \
+	-e "github.com/redhat-developer/observability-operator/v3/controllers/reconcilers/csv/" \
+	-e "github.com/redhat-developer/observability-operator/v3/controllers/reconcilers/grafana_configuration/" \
+	-e "github.com/redhat-developer/observability-operator/v3/controllers/reconcilers/grafana_installation/" \
+	-e "github.com/redhat-developer/observability-operator/v3/controllers/reconcilers/prometheus_installation/" \
+	-e "github.com/redhat-developer/observability-operator/v3/controllers/reconcilers/prometheus_configuration/" \
+	-e "github.com/redhat-developer/observability-operator/v3/controllers/reconcilers/promtail_installation/" \
+	-e "github.com/redhat-developer/observability-operator/v3/controllers/token/token_fetcher.go" \
+	-e "github.com/redhat-developer/observability-operator/v3/controllers/reconcilers/reconciler.go" \
+	-e "github.com/redhat-developer/observability-operator/v3/controllers/observability_controller.go" \
+	-e "github.com/redhat-developer/observability-operator/v3/controllers/suite_test.go" \
+	-e "github.com/redhat-developer/observability-operator/v3/runners" \
+	-e "github.com/redhat-developer/observability-operator/v3/main.go" \
 	cover.out.tmp > cover.out
 	rm cover.out.tmp
 


### PR DESCRIPTION
This PR is to close off a number of unit test Jiras within the overall testing epic. [Epic link](https://issues.redhat.com/browse/MGDSTRM-1050)

A number of packages contain files unsuitable for unit testing and so can be ignored for unit test coverage. This change adds these to the list of ignored files/packages in the `make test/unit` target.

**Packages/files to ignore**

- controllers/reconcilers/alertmanager_installation
- controllers/reconcilers/csv
- controllers/reconcilers/grafana_configuration
- controllers/reconcilers/grafana_installation
- controllers/reconcilers/prometheus_installation
- controllers/reconcilers/promtail_installation
- controllers/token
- controllers/reconcilers/prometheus_configuration