### PR TITLE
chore: change image pull policy to 'IfNotPresent'

### DIFF
--- a/bundle/manifests/observability-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/observability-operator.clusterserviceversion.yaml
@@ -296,7 +296,7 @@ spec:
                 command:
                 - /manager
                 image: quay.io/rhoas/observability-operator:v3.0.10
-                imagePullPolicy: Always
+                imagePullPolicy: IfNotPresent
                 name: manager
                 ports:
                 - containerPort: 9443

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -29,7 +29,7 @@ spec:
         args:
         - --enable-leader-election
         image: controller:latest
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: manager
         resources:
           limits:


### PR DESCRIPTION
This PR changes the image pull policy to `IfNotPresent` for deployments.

**Verification**
- Deploy latest version of Observability Operator (v3.0.10)
- Note the `ImagePullPolicy` in the `observability-operator-controller-manager` YAML is set to `Always`
- Deploy the Operator using an image including this change (image available at `quay.io/vmanley/observability-operator-index:v3.0.11`)
- Note the `ImagePullPolicy` in the `observability-operator-controller-manager` YAML is now set to `IfNotPresent`
