### PR TITLE
Making the Grafana Version Configurable.

### DIFF
--- a/api/v1/index.go
+++ b/api/v1/index.go
@@ -17,6 +17,7 @@ type RepositoryInfo struct {
 type GrafanaIndex struct {
 	Dashboards             []string           `json:"dashboards"`
 	DashboardLabelSelector *v13.LabelSelector `json:"dashboardLabelSelector,omitempty"`
+	GrafanaVersion         string             `json:"grafanaVersion,omitempty"`
 }
 
 type DexConfig struct {

--- a/api/v1/observability_types.go
+++ b/api/v1/observability_types.go
@@ -87,6 +87,7 @@ type SelfContained struct {
 	PrometheusOperatorResourceRequirement v1.ResourceRequirements  `json:"prometheusOperatorResourceRequirement,omitempty"`
 	GrafanaResourceRequirement            *v1.ResourceRequirements `json:"grafanaResourceRequirement,omitempty"`
 	GrafanaOperatorResourceRequirement    v1.ResourceRequirements  `json:"grafanaOperatorResourceRequirement,omitempty"`
+	GrafanaVersion                        string                   `json:"grafanaVersion,omitempty"`
 }
 
 // ObservabilitySpec defines the desired state of Observability

--- a/api/v1/observability_types.go
+++ b/api/v1/observability_types.go
@@ -87,7 +87,6 @@ type SelfContained struct {
 	PrometheusOperatorResourceRequirement v1.ResourceRequirements  `json:"prometheusOperatorResourceRequirement,omitempty"`
 	GrafanaResourceRequirement            *v1.ResourceRequirements `json:"grafanaResourceRequirement,omitempty"`
 	GrafanaOperatorResourceRequirement    v1.ResourceRequirements  `json:"grafanaOperatorResourceRequirement,omitempty"`
-	GrafanaVersion                        string                   `json:"grafanaVersion,omitempty"`
 }
 
 // ObservabilitySpec defines the desired state of Observability

--- a/controllers/model/grafana_resources.go
+++ b/controllers/model/grafana_resources.go
@@ -118,6 +118,12 @@ func GetGrafanaResourceRequirement(cr *v1.Observability) *v14.ResourceRequiremen
 	return &v14.ResourceRequirements{}
 }
 
+func GetGrafanaVersion(cr *v1.Observability, indexes []v1.RepositoryIndex) string {
+	config := indexes[0].Config
+	return config.Grafana.GrafanaVersion
+}
+
+
 func GetGrafanaOperatorResourceRequirement(cr *v1.Observability) v14.ResourceRequirements {
 	if cr.Spec.SelfContained != nil {
 		return cr.Spec.SelfContained.GrafanaOperatorResourceRequirement

--- a/controllers/model/grafana_resources.go
+++ b/controllers/model/grafana_resources.go
@@ -122,9 +122,8 @@ func GetGrafanaVersion(indexes []v1.RepositoryIndex) string {
 	config := indexes[0].Config
 	if config != nil && config.Grafana.GrafanaVersion != "" {
 		return config.Grafana.GrafanaVersion
-	}else{
-		return ""
 	}
+	return ""
 }
 
 func GetGrafanaOperatorResourceRequirement(cr *v1.Observability) v14.ResourceRequirements {

--- a/controllers/model/grafana_resources.go
+++ b/controllers/model/grafana_resources.go
@@ -118,14 +118,14 @@ func GetGrafanaResourceRequirement(cr *v1.Observability) *v14.ResourceRequiremen
 	return &v14.ResourceRequirements{}
 }
 
-func GetGrafanaVersion(cr *v1.Observability, indexes []v1.RepositoryIndex) string {
-	if cr.Spec.SelfContained != nil && cr.Spec.SelfContained.GrafanaVersion != nil {
-		config := indexes[0].Config
+func GetGrafanaVersion(indexes []v1.RepositoryIndex) string {
+	config := indexes[0].Config
+	if config.Grafana.GrafanaVersion != "" {
 		return config.Grafana.GrafanaVersion
+	} else {
+		return "7.3.10"
 	}
-	return "7.3.10"
 }
-
 
 func GetGrafanaOperatorResourceRequirement(cr *v1.Observability) v14.ResourceRequirements {
 	if cr.Spec.SelfContained != nil {

--- a/controllers/model/grafana_resources.go
+++ b/controllers/model/grafana_resources.go
@@ -120,7 +120,7 @@ func GetGrafanaResourceRequirement(cr *v1.Observability) *v14.ResourceRequiremen
 
 func GetGrafanaVersion(indexes []v1.RepositoryIndex) string {
 	config := indexes[0].Config
-	if config.Grafana.GrafanaVersion != "" {
+	if config != nil && config.Grafana.GrafanaVersion != "" {
 		return config.Grafana.GrafanaVersion
 	}else{
 		return ""

--- a/controllers/model/grafana_resources.go
+++ b/controllers/model/grafana_resources.go
@@ -119,8 +119,11 @@ func GetGrafanaResourceRequirement(cr *v1.Observability) *v14.ResourceRequiremen
 }
 
 func GetGrafanaVersion(cr *v1.Observability, indexes []v1.RepositoryIndex) string {
-	config := indexes[0].Config
-	return config.Grafana.GrafanaVersion
+	if cr.Spec.SelfContained != nil && cr.Spec.SelfContained.GrafanaVersion != nil {
+		config := indexes[0].Config
+		return config.Grafana.GrafanaVersion
+	}
+	return "7.3.10"
 }
 
 

--- a/controllers/model/grafana_resources.go
+++ b/controllers/model/grafana_resources.go
@@ -122,8 +122,8 @@ func GetGrafanaVersion(indexes []v1.RepositoryIndex) string {
 	config := indexes[0].Config
 	if config.Grafana.GrafanaVersion != "" {
 		return config.Grafana.GrafanaVersion
-	} else {
-		return "7.3.10"
+	}else{
+		return ""
 	}
 }
 

--- a/controllers/model/grafana_resources.go
+++ b/controllers/model/grafana_resources.go
@@ -119,9 +119,11 @@ func GetGrafanaResourceRequirement(cr *v1.Observability) *v14.ResourceRequiremen
 }
 
 func GetGrafanaVersion(indexes []v1.RepositoryIndex) string {
-	config := indexes[0].Config
-	if config != nil && config.Grafana.GrafanaVersion != "" {
-		return config.Grafana.GrafanaVersion
+	if len(indexes) > 0 {
+		config := indexes[0].Config
+		if config != nil && config.Grafana.GrafanaVersion != "" {
+			return config.Grafana.GrafanaVersion
+		}
 	}
 	return ""
 }

--- a/controllers/model/grafana_resources_test.go
+++ b/controllers/model/grafana_resources_test.go
@@ -17,6 +17,16 @@ var (
 	defaultGrafanaName         = "kafka-grafana"
 	objectMetaWithNamespace    = v12.ObjectMeta{Namespace: testNamespace}
 	labelSelectorWithNamespace = &v12.LabelSelector{MatchLabels: map[string]string{"namespace": "test"}}
+	testRepoConfig             = []v1.RepositoryIndex{
+		{
+			Config: &v1.RepositoryConfig{
+				Grafana: &v1.GrafanaIndex{
+					DashboardLabelSelector: labelSelectorWithNamespace,
+					GrafanaVersion:         "8.4.1",
+				},
+			},
+		},
+	}
 )
 
 func TestGrafanaResources_GetDefaultNameGrafana(t *testing.T) {
@@ -87,6 +97,41 @@ func TestGrafanaResources_GetGrafanaCatalogSource(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := GetGrafanaCatalogSource(tt.args.cr)
+			Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestGrafanaResources_GetGrafanaVersion(t *testing.T) {
+	type args struct {
+		indexes []v1.RepositoryIndex
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "returns empty string if no version is declared in the Repository Index",
+			args: args{
+				indexes: []v1.RepositoryIndex{},
+			},
+			want: "",
+		},
+		{
+			name: "return version specified in the Repository Index",
+			args: args{
+				indexes: testRepoConfig,
+			},
+			want: "8.4.1",
+		},
+	}
+
+	RegisterTestingT(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetGrafanaVersion(tt.args.indexes)
 			Expect(result).To(Equal(tt.want))
 		})
 	}

--- a/controllers/reconcilers/configuration/grafana.go
+++ b/controllers/reconcilers/configuration/grafana.go
@@ -17,6 +17,7 @@ func (r *Reconciler) reconcileGrafanaCr(ctx context.Context, cr *v1.Observabilit
 
 	var f = false
 	var t = true
+	version := model.GetGrafanaVersion(cr, indexes)
 
 	_, err := controllerutil.CreateOrUpdate(ctx, r.client, grafana, func() error {
 		grafana.Spec = v1alpha1.GrafanaSpec{
@@ -79,6 +80,7 @@ func (r *Reconciler) reconcileGrafanaCr(ctx context.Context, cr *v1.Observabilit
 					},
 				},
 			},
+			BaseImage: "docker.io/grafana/grafana:" + version,
 			DashboardLabelSelector: []*metav1.LabelSelector{
 				model.GetGrafanaDashboardLabelSelectors(cr, indexes),
 			},

--- a/controllers/reconcilers/configuration/grafana.go
+++ b/controllers/reconcilers/configuration/grafana.go
@@ -17,7 +17,11 @@ func (r *Reconciler) reconcileGrafanaCr(ctx context.Context, cr *v1.Observabilit
 
 	var f = false
 	var t = true
-	version := model.GetGrafanaVersion(indexes)
+
+	version := "docker.io/grafana/grafana:" + model.GetGrafanaVersion(indexes)
+	if version == "docker.io/grafana/grafana:" {
+		version = ""
+	}
 
 	_, err := controllerutil.CreateOrUpdate(ctx, r.client, grafana, func() error {
 		grafana.Spec = v1alpha1.GrafanaSpec{
@@ -80,7 +84,7 @@ func (r *Reconciler) reconcileGrafanaCr(ctx context.Context, cr *v1.Observabilit
 					},
 				},
 			},
-			BaseImage: "docker.io/grafana/grafana:" + version,
+			BaseImage: version,
 			DashboardLabelSelector: []*metav1.LabelSelector{
 				model.GetGrafanaDashboardLabelSelectors(cr, indexes),
 			},

--- a/controllers/reconcilers/configuration/grafana.go
+++ b/controllers/reconcilers/configuration/grafana.go
@@ -13,6 +13,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
+const (
+	GrafanaBaseImage = "docker.io/grafana/grafana:"
+)
+
 func (r *Reconciler) reconcileGrafanaCr(ctx context.Context, cr *v1.Observability, indexes []v1.RepositoryIndex) error {
 	grafana := model.GetGrafanaCr(cr)
 
@@ -20,9 +24,9 @@ func (r *Reconciler) reconcileGrafanaCr(ctx context.Context, cr *v1.Observabilit
 	var t = true
 
 	specVer, verError := semver.ParseTolerant(model.GetGrafanaVersion(indexes))
-	version := ""
+	GrafanaImage := ""
 	if specVer.String() != "0.0.0" && verError == nil {
-		version = "docker.io/grafana/grafana:" + specVer.String()
+		GrafanaImage = GrafanaBaseImage + specVer.String()
 	}
 
 	_, err := controllerutil.CreateOrUpdate(ctx, r.client, grafana, func() error {
@@ -86,7 +90,7 @@ func (r *Reconciler) reconcileGrafanaCr(ctx context.Context, cr *v1.Observabilit
 					},
 				},
 			},
-			BaseImage: version,
+			BaseImage: GrafanaImage,
 			DashboardLabelSelector: []*metav1.LabelSelector{
 				model.GetGrafanaDashboardLabelSelectors(cr, indexes),
 			},

--- a/controllers/reconcilers/configuration/grafana.go
+++ b/controllers/reconcilers/configuration/grafana.go
@@ -3,6 +3,7 @@ package configuration
 import (
 	"context"
 
+	"github.com/blang/semver"
 	"github.com/integr8ly/grafana-operator/v3/pkg/apis/integreatly/v1alpha1"
 	v1 "github.com/redhat-developer/observability-operator/v3/api/v1"
 	"github.com/redhat-developer/observability-operator/v3/controllers/model"
@@ -18,9 +19,10 @@ func (r *Reconciler) reconcileGrafanaCr(ctx context.Context, cr *v1.Observabilit
 	var f = false
 	var t = true
 
-	version := "docker.io/grafana/grafana:" + model.GetGrafanaVersion(indexes)
-	if version == "docker.io/grafana/grafana:" {
-		version = ""
+	specVer, verError := semver.ParseTolerant(model.GetGrafanaVersion(indexes))
+	version := ""
+	if specVer.String() != "0.0.0" && verError == nil {
+		version = "docker.io/grafana/grafana:" + specVer.String()
 	}
 
 	_, err := controllerutil.CreateOrUpdate(ctx, r.client, grafana, func() error {

--- a/controllers/reconcilers/configuration/grafana.go
+++ b/controllers/reconcilers/configuration/grafana.go
@@ -17,7 +17,7 @@ func (r *Reconciler) reconcileGrafanaCr(ctx context.Context, cr *v1.Observabilit
 
 	var f = false
 	var t = true
-	version := model.GetGrafanaVersion(cr, indexes)
+	version := model.GetGrafanaVersion(indexes)
 
 	_, err := controllerutil.CreateOrUpdate(ctx, r.client, grafana, func() error {
 		grafana.Spec = v1alpha1.GrafanaSpec{


### PR DESCRIPTION
The changes made are to make the Grafana Version configurable through the index.json located [here](https://github.com/bf2fc6cc711aee1a0c2a/observability-resources-mk/blob/main/resources/index.json) in the observability resources repo. 

By adding the **grafanaVersion** field followed by version tag.
![image](https://user-images.githubusercontent.com/59835082/173562467-ee7c92e1-69cb-4c1a-a6f9-32e510c970f6.png)
If left empty or blank the Grafana Operator uses a hard coded Grafana Version defined within itself.
