### PR TITLE
Self Contained Grafana Version Configuration

### DIFF
--- a/api/v1/observability_types.go
+++ b/api/v1/observability_types.go
@@ -87,6 +87,7 @@ type SelfContained struct {
 	PrometheusOperatorResourceRequirement v1.ResourceRequirements  `json:"prometheusOperatorResourceRequirement,omitempty"`
 	GrafanaResourceRequirement            *v1.ResourceRequirements `json:"grafanaResourceRequirement,omitempty"`
 	GrafanaOperatorResourceRequirement    v1.ResourceRequirements  `json:"grafanaOperatorResourceRequirement,omitempty"`
+	GrafanaVersion                        string                   `json:"grafanaVersion,omitempty"`
 }
 
 // ObservabilitySpec defines the desired state of Observability

--- a/config/crd/bases/observability.redhat.com_observabilities.yaml
+++ b/config/crd/bases/observability.redhat.com_observabilities.yaml
@@ -840,6 +840,8 @@ spec:
                           to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                         type: object
                     type: object
+                  grafanaVersion:
+                    type: string
                   overrideSelectors:
                     type: boolean
                   podMonitorLabelSelector:

--- a/controllers/model/grafana_resources.go
+++ b/controllers/model/grafana_resources.go
@@ -118,12 +118,15 @@ func GetGrafanaResourceRequirement(cr *v1.Observability) *v14.ResourceRequiremen
 	return &v14.ResourceRequirements{}
 }
 
-func GetGrafanaVersion(indexes []v1.RepositoryIndex) string {
+func GetGrafanaVersion(indexes []v1.RepositoryIndex, cr *v1.Observability) string {
 	if len(indexes) > 0 {
 		config := indexes[0].Config
 		if config != nil && config.Grafana.GrafanaVersion != "" {
 			return config.Grafana.GrafanaVersion
 		}
+	}
+	if cr.Spec.SelfContained != nil && cr.Spec.SelfContained.GrafanaVersion != "" {
+		return cr.Spec.SelfContained.GrafanaVersion
 	}
 	return ""
 }

--- a/controllers/reconcilers/configuration/grafana.go
+++ b/controllers/reconcilers/configuration/grafana.go
@@ -23,7 +23,7 @@ func (r *Reconciler) reconcileGrafanaCr(ctx context.Context, cr *v1.Observabilit
 	var f = false
 	var t = true
 
-	specVer, verError := semver.ParseTolerant(model.GetGrafanaVersion(indexes))
+	specVer, verError := semver.ParseTolerant(model.GetGrafanaVersion(indexes, cr))
 	GrafanaImage := ""
 	if specVer.String() != "0.0.0" && verError == nil {
 		GrafanaImage = GrafanaBaseImage + specVer.String()


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/59835082/176226164-6d315041-bee9-4870-b967-692c6c98a3cc.png)

Added the functionality of configuring the Version of Grafana that is used through the selfContained part of the Observability Stacks selfContained section in the yaml. You can test this in crc by adding ```grafanaVersion: 8.4.1``` as above.