### PR TITLE
fix: fix duplicate PVC creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ previously mentioned
 ### Prerequisite Tools
 
 * golang 1.16+
-* operator-sdk v1.1.0
+* operator-sdk v1.4.2
 * [CodeReady Containers](https://github.com/code-ready/crc) 1.18 (OCP 4.6.1) or later
 * [OpenShift command line tool](https://developers.redhat.com/openshift/command-line-tools)
 

--- a/controllers/reconcilers/configuration/prometheus.go
+++ b/controllers/reconcilers/configuration/prometheus.go
@@ -483,6 +483,10 @@ func (r *Reconciler) reconcilePrometheus(ctx context.Context, cr *v1.Observabili
 //construct Prometheus storage spec with either default or override value from resources
 func getPrometheusStorageSpecHelper(cr *v1.Observability, indexes []v1.RepositoryIndex) (*prometheusv1.StorageSpec, error) {
 	prometheusStorageSpec := cr.Spec.Storage.PrometheusStorageSpec
+	if cr.ExternalSyncDisabled() {
+		return prometheusStorageSpec, nil
+	}
+
 	customStorageSize := model.GetPrometheusStorageSize(cr, indexes)
 	if customStorageSize == "" {
 		return prometheusStorageSpec, nil


### PR DESCRIPTION
Jira: [MGDSTRM-9126](https://issues.redhat.com/browse/MGDSTRM-9126)

This change resolves a bug where duplicate PVC can be created when using self-contained mode of the Operator.
Duplicate PVC issue was observed when Operator was upgraded from v3.0.10 to v3.0.11.

### Verification

1. Install v3.0.10 of the Operator with ConfigMap named `observability-operator-no-init` applied to the same namespace. This runs the Operator in self-contained mode. The following catalogSource can be applied to namespace to install the correct verison through OperatorHub:
```
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
  name: observability-operator-manifests
  namespace: <your-namespace>
spec:
  sourceType: grpc
  image: quay.io/rhoas/observability-operator-index:v3.0.10
```
2. Apply a CR to the Operator that includes a Prometheus storage claim and repo sync disabled. For example:
```
apiVersion: observability.redhat.com/v1
kind: Observability
metadata:
  name: observability-stack
  namespace: <your-namespace>
  labels:
    managed-by: observability-operator
spec:
  configurationSelector:
    matchLabels:
      configures: "observability-operator"
  resyncPeriod: 1h
  retention: 45d
  selfContained:
    alertManagerResourceRequirement: {}
    disableBlackboxExporter: true
    grafanaOperatorResourceRequirement: {}
    prometheusOperatorResourceRequirement: {}
    prometheusResourceRequirement: {}
    disableRepoSync: true
  storage:
    prometheus:
      volumeClaimTemplate:
        metadata: {}
        spec:
          resources:
            requests:
              storage: 50Gi
```
3. Allow the Operator to complete configuration and check that the Prometheus PVC has been created. Name of PVC should be `prometheus-prometheus-db-prometheus-prometheus-0` if above sample CR is used.
4. Upgrade the Operator by modifying your catalogSource to point to image of this PR change . The following catalogSource can be used:
```
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
  name: observability-operator-manifests
  namespace: <your-namespace>
spec:
  sourceType: grpc
  image: quay.io/vmanley/observability-operator-index:v3.0.13
```
5. Allow a couple of minutes for the Operator to be upgraded. This can be checked in UI under Operators > Installed Operators to ensure version has been upgraded.
6. Once Operator is fully upgraded ensure the existing PVC is still the only PVC created by the Operator and no duplicate has been created.
