### PR TITLE
Resource name migration

### DIFF
--- a/api/v1/observability_types.go
+++ b/api/v1/observability_types.go
@@ -42,6 +42,7 @@ const (
 	AlertmanagerInstallation ObservabilityStageName = "AlertmanagerInstallation"
 	Configuration            ObservabilityStageName = "configuration"
 	LoggingInstallation      ObservabilityStageName = "Logging"
+	Migration                ObservabilityStageName = "resource name migration"
 )
 
 const (
@@ -122,6 +123,7 @@ type ObservabilityStatus struct {
 	TokenExpires int64                    `json:"tokenExpires,omitempty"`
 	ClusterID    string                   `json:"clusterId,omitempty"`
 	LastSynced   int64                    `json:"lastSynced,omitempty"`
+	Migrated     bool                     `json:"migrated,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/bundle/manifests/observability.redhat.com_observabilities.yaml
+++ b/bundle/manifests/observability.redhat.com_observabilities.yaml
@@ -1238,6 +1238,8 @@ spec:
               lastSynced:
                 format: int64
                 type: integer
+              migrated:
+                type: boolean
               stage:
                 type: string
               stageStatus:

--- a/config/crd/bases/observability.redhat.com_observabilities.yaml
+++ b/config/crd/bases/observability.redhat.com_observabilities.yaml
@@ -1915,6 +1915,8 @@ spec:
               lastSynced:
                 format: int64
                 type: integer
+              migrated:
+                type: boolean
               stage:
                 type: string
               stageStatus:

--- a/controllers/model/alertmanager_resources.go
+++ b/controllers/model/alertmanager_resources.go
@@ -11,11 +11,15 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	AlertManagerOldDefaultName = "kafka-alertmanager"
+)
+
 func GetDefaultNameAlertmanager(cr *v1.Observability) string {
 	if cr.Spec.SelfContained != nil && cr.Spec.AlertManagerDefaultName != "" {
 		return cr.Spec.AlertManagerDefaultName
 	}
-	return "kafka-alertmanager"
+	return "observability-alertmanager"
 }
 
 func GetAlertmanagerProxySecret(cr *v1.Observability) *v13.Secret {

--- a/controllers/model/alertmanager_resources_test.go
+++ b/controllers/model/alertmanager_resources_test.go
@@ -17,10 +17,10 @@ import (
 )
 
 var (
-	defaultAlertManagerName              = "kafka-alertmanager"
+	defaultAlertManagerName              = "observability-alertmanager"
 	defaultAlertmanagerObjectMeta        = metav1.ObjectMeta{Name: defaultAlertManagerName}
 	alertmanagerTestName                 = "test-alert-manager-name"
-	alertmanagerServiceAccountAnnotation = map[string]string{"serviceaccounts.openshift.io/oauth-redirectreference.primary": "{\"kind\":\"OAuthRedirectReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"Route\",\"name\":\"kafka-alertmanager\"}}"}
+	alertmanagerServiceAccountAnnotation = map[string]string{"serviceaccounts.openshift.io/oauth-redirectreference.primary": "{\"kind\":\"OAuthRedirectReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"Route\",\"name\":\"observability-alertmanager\"}}"}
 	testResourceList                     = map[corev1.ResourceName]resource.Quantity{corev1.ResourceStorage: resource.MustParse("10Gi")}
 )
 
@@ -61,7 +61,7 @@ func TestAlertManagerResources_GetDefaultNameAlertmanager(t *testing.T) {
 			want: alertmanagerTestName,
 		},
 		{
-			name: "return `kafka-alertmanager` if NOT self contained and spec AlertManagerDefaultName is empty",
+			name: "return `observability-alertmanager` if NOT self contained and spec AlertManagerDefaultName is empty",
 			args: args{
 				cr: buildObservabilityCR(nil),
 			},

--- a/controllers/model/grafana_resources.go
+++ b/controllers/model/grafana_resources.go
@@ -12,11 +12,13 @@ import (
 
 var defaultGrafanaLabelSelectors = map[string]string{"app": "strimzi"}
 
+const GrafanaOldDefaultName = "kafka-grafana"
+
 func GetDefaultNameGrafana(cr *v1.Observability) string {
 	if cr.Spec.SelfContained != nil && cr.Spec.GrafanaDefaultName != "" {
 		return cr.Spec.GrafanaDefaultName
 	}
-	return "kafka-grafana"
+	return "observability-grafana"
 }
 
 func GetGrafanaCatalogSource(cr *v1.Observability) *v1alpha1.CatalogSource {

--- a/controllers/model/grafana_resources_test.go
+++ b/controllers/model/grafana_resources_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 var (
-	defaultGrafanaName         = "kafka-grafana"
+	defaultGrafanaName         = "observability-grafana"
 	objectMetaWithNamespace    = v12.ObjectMeta{Namespace: testNamespace}
 	labelSelectorWithNamespace = &v12.LabelSelector{MatchLabels: map[string]string{"namespace": "test"}}
 	testRepoConfig             = []v1.RepositoryIndex{
@@ -40,7 +40,7 @@ func TestGrafanaResources_GetDefaultNameGrafana(t *testing.T) {
 		want string
 	}{
 		{
-			name: "returns 'kafka-grafana' if NOT self contained",
+			name: "returns 'observability-grafana' if NOT self contained",
 			args: args{
 				cr: buildObservabilityCR(nil),
 			},

--- a/controllers/model/prometheus_resources.go
+++ b/controllers/model/prometheus_resources.go
@@ -27,7 +27,7 @@ var defaultPrometheusLabelSelectors = map[string]string{"app": "strimzi"}
 const (
 	PrometheusVersion        = "v2.22.2"
 	PrometheusDefaultStorage = "250Gi"
-	PrometheusOldRouteName   = "kafka-prometheus"
+	PrometheusOldDefaultName = "kafka-prometheus"
 )
 
 func GetPrometheusNamespace(cr *v1.Observability) *v13.Namespace {

--- a/controllers/model/prometheus_resources.go
+++ b/controllers/model/prometheus_resources.go
@@ -27,6 +27,7 @@ var defaultPrometheusLabelSelectors = map[string]string{"app": "strimzi"}
 const (
 	PrometheusVersion        = "v2.22.2"
 	PrometheusDefaultStorage = "250Gi"
+	PrometheusOldRouteName   = "kafka-prometheus"
 )
 
 func GetPrometheusNamespace(cr *v1.Observability) *v13.Namespace {
@@ -41,7 +42,7 @@ func GetDefaultNamePrometheus(cr *v1.Observability) string {
 	if cr.Spec.SelfContained != nil && cr.Spec.PrometheusDefaultName != "" {
 		return cr.Spec.PrometheusDefaultName
 	}
-	return "kafka-prometheus"
+	return "observability-prometheus"
 }
 
 func GetPrometheusAuthTokenLifetimes(cr *v1.Observability) *v13.ConfigMap {

--- a/controllers/model/prometheus_resources_test.go
+++ b/controllers/model/prometheus_resources_test.go
@@ -17,8 +17,8 @@ import (
 var (
 	objectMetaWithPrometheusName       = v12.ObjectMeta{Name: defaultPrometheusName}
 	testNamespace                      = "testNamespace"
-	defaultPrometheusName              = "kafka-prometheus"
-	serviceAccountPrometheusAnnotation = map[string]string{"serviceaccounts.openshift.io/oauth-redirectreference.primary": "{\"kind\":\"OAuthRedirectReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"Route\",\"name\":\"kafka-prometheus\"}}"}
+	defaultPrometheusName              = "observability-prometheus"
+	serviceAccountPrometheusAnnotation = map[string]string{"serviceaccounts.openshift.io/oauth-redirectreference.primary": "{\"kind\":\"OAuthRedirectReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"Route\",\"name\":\"observability-prometheus\"}}"}
 	testPattern                        = []string{"test1", "test2"}
 	testFederationConfigBearerToken    = `
 - job_name: openshift-monitoring-federation
@@ -93,7 +93,7 @@ func TestPrometheusResources_GetDefaultNamePrometheus(t *testing.T) {
 		want string
 	}{
 		{
-			name: "returns 'kafka-prometheus' if NOT self contained",
+			name: "returns 'observability-prometheus' if NOT self contained",
 			args: args{
 				cr: buildObservabilityCR(nil),
 			},

--- a/controllers/model/promtail_resource_test.go
+++ b/controllers/model/promtail_resource_test.go
@@ -247,7 +247,7 @@ func TestPromtailResources_GetPromtailServiceAccount(t *testing.T) {
 			},
 			want: &corev1.ServiceAccount{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "kafka-promtail",
+					Name:      "observability-promtail",
 					Namespace: testNamespace,
 				},
 			},
@@ -279,7 +279,7 @@ func TestPromtailResources_GetPromtailClusterRole(t *testing.T) {
 			},
 			want: &rbacv1.ClusterRole{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "kafka-promtail",
+					Name: "observability-promtail",
 				},
 			},
 		},
@@ -310,7 +310,7 @@ func TestPromtailResources_GetPromtailClusterRoleBinding(t *testing.T) {
 			},
 			want: &rbacv1.ClusterRoleBinding{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "kafka-promtail",
+					Name: "observability-promtail",
 				},
 			},
 		},

--- a/controllers/model/promtail_resources.go
+++ b/controllers/model/promtail_resources.go
@@ -15,6 +15,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	PromtailOldDefaultName = "kafka-promtail"
+	PromtailDefaultName    = "observability-promtail"
+)
+
 func GetPromtailConfigmap(cr *v1.Observability, name string) *v12.ConfigMap {
 	return &v12.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -42,7 +47,7 @@ func GetPromtailDaemonSet(cr *v1.Observability, name string) *v13.DaemonSet {
 func GetPromtailServiceAccount(cr *v1.Observability) *v12.ServiceAccount {
 	return &v12.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kafka-promtail",
+			Name:      PromtailDefaultName,
 			Namespace: cr.Namespace,
 		},
 	}
@@ -51,7 +56,7 @@ func GetPromtailServiceAccount(cr *v1.Observability) *v12.ServiceAccount {
 func GetPromtailClusterRole(cr *v1.Observability) *v14.ClusterRole {
 	return &v14.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "kafka-promtail",
+			Name: PromtailDefaultName,
 		},
 	}
 }
@@ -59,7 +64,7 @@ func GetPromtailClusterRole(cr *v1.Observability) *v14.ClusterRole {
 func GetPromtailClusterRoleBinding(cr *v1.Observability) *v14.ClusterRoleBinding {
 	return &v14.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "kafka-promtail",
+			Name: PromtailDefaultName,
 		},
 	}
 }

--- a/controllers/observability_controller.go
+++ b/controllers/observability_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/redhat-developer/observability-operator/v3/controllers/reconcilers/migration"
 	"io/ioutil"
 	"os"
 	"reflect"
@@ -282,6 +283,7 @@ func (r *ObservabilityReconciler) InitializeOperand(mgr ctrl.Manager) error {
 
 func (r *ObservabilityReconciler) getInstallationStages() []apiv1.ObservabilityStageName {
 	return []apiv1.ObservabilityStageName{
+		apiv1.Migration,
 		apiv1.TokenRequest,
 		apiv1.PrometheusInstallation,
 		apiv1.PrometheusConfiguration,
@@ -420,6 +422,9 @@ func (r *ObservabilityReconciler) getReconcilerForStage(stage apiv1.Observabilit
 
 	case apiv1.LoggingInstallation:
 		return logging_installation.NewReconciler(r.Client, r.Log)
+
+	case apiv1.Migration:
+		return migration.NewReconciler(r.Client, r.Log)
 
 	default:
 		return nil

--- a/controllers/reconcilers/grafana_configuration/grafana_configuration_reconciler.go
+++ b/controllers/reconcilers/grafana_configuration/grafana_configuration_reconciler.go
@@ -215,7 +215,7 @@ func (r *Reconciler) reconcileGrafanaDatasource(ctx context.Context, cr *v1.Obse
 	url := fmt.Sprintf("http://prometheus-operated.%s:9090", cr.Namespace)
 
 	_, err := controllerutil.CreateOrUpdate(ctx, r.client, datasource, func() error {
-		datasource.Spec.Name = "kafka-prometheus.yaml"
+		datasource.Spec.Name = "observability-prometheus.yaml"
 		datasource.Spec.Datasources = []v1alpha1.GrafanaDataSourceFields{
 			{
 				Name:      "Prometheus",

--- a/controllers/reconcilers/migration/resource_name_migration.go
+++ b/controllers/reconcilers/migration/resource_name_migration.go
@@ -1,0 +1,89 @@
+package migration
+
+import (
+	"context"
+	"fmt"
+	"github.com/go-logr/logr"
+	v1 "github.com/redhat-developer/observability-operator/v3/api/v1"
+	"github.com/redhat-developer/observability-operator/v3/controllers/model"
+	"github.com/redhat-developer/observability-operator/v3/controllers/reconcilers"
+	v13 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type Reconciler struct {
+	client client.Client
+	logger logr.Logger
+}
+
+func NewReconciler(client client.Client, logger logr.Logger) reconcilers.ObservabilityReconciler {
+	return &Reconciler{
+		client: client,
+		logger: logger,
+	}
+}
+
+func (r *Reconciler) Cleanup(ctx context.Context, cr *v1.Observability) (v1.ObservabilityStageStatus, error) {
+	return v1.ResultSuccess, nil
+}
+
+func (r *Reconciler) Reconcile(ctx context.Context, cr *v1.Observability, s *v1.ObservabilityStatus) (v1.ObservabilityStageStatus, error) {
+	if s.Migrated {
+		return v1.ResultSuccess, nil
+	}
+
+	prometheusCr := model.GetPrometheus(cr)
+	prometheusCr.Name = model.PrometheusOldDefaultName
+
+	err := r.client.Delete(ctx, prometheusCr)
+	if err != nil {
+		return v1.ResultFailed, err
+	}
+
+	r.waitForPrometheusToBeRemoved(ctx, cr, model.PrometheusOldDefaultName)
+
+	prometheusRoute := model.GetPrometheusRoute(cr)
+	prometheusRoute.Name = model.PrometheusOldDefaultName
+	err = r.client.Delete(ctx, prometheusRoute)
+	if err != nil {
+		return v1.ResultFailed, err
+	}
+
+	prometheusService := model.GetPrometheusService(cr)
+	prometheusService.Name = model.PrometheusOldDefaultName
+	err = r.client.Delete(ctx, prometheusService)
+	if err != nil {
+		return v1.ResultFailed, err
+	}
+
+	prometheusServiceAccount := model.GetPrometheusServiceAccount(cr)
+	prometheusServiceAccount.Name = model.PrometheusOldDefaultName
+	err = r.client.Delete(ctx, prometheusServiceAccount)
+	if err != nil {
+		return v1.ResultFailed, err
+	}
+
+	s.Migrated = true
+
+	return v1.ResultSuccess, nil
+}
+
+func (r *Reconciler) waitForPrometheusToBeRemoved(ctx context.Context, cr *v1.Observability, prometheusName string) (v1.ObservabilityStageStatus, error) {
+	list := &v13.StatefulSetList{}
+	opts := &client.ListOptions{
+		Namespace: cr.Namespace,
+	}
+	err := r.client.List(ctx, list, opts)
+	if err != nil && !errors.IsNotFound(err) {
+		return v1.ResultFailed, err
+	}
+
+	for _, ss := range list.Items {
+		if ss.Name == fmt.Sprintf("prometheus-%s", prometheusName) {
+			return v1.ResultInProgress, nil
+		}
+	}
+
+	return v1.ResultSuccess, nil
+}

--- a/controllers/reconcilers/migration/resource_name_migration.go
+++ b/controllers/reconcilers/migration/resource_name_migration.go
@@ -9,10 +9,8 @@ import (
 	"github.com/redhat-developer/observability-operator/v3/controllers/model"
 	"github.com/redhat-developer/observability-operator/v3/controllers/reconcilers"
 	"github.com/redhat-developer/observability-operator/v3/controllers/utils"
+	"k8s.io/apimachinery/pkg/api/errors"
 
-	//v13 "k8s.io/api/apps/v1"
-
-	//"k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -44,7 +42,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, cr *v1.Observability, s *v1.
 		prometheusCr.Name = model.PrometheusOldDefaultName
 
 		err := r.client.Delete(ctx, prometheusCr)
-		if err != nil {
+		if err != nil && !errors.IsNotFound(err) {
 			return v1.ResultFailed, err
 		}
 
@@ -53,37 +51,35 @@ func (r *Reconciler) Reconcile(ctx context.Context, cr *v1.Observability, s *v1.
 		prometheusRoute := model.GetPrometheusRoute(cr)
 		prometheusRoute.Name = model.PrometheusOldDefaultName
 		err = r.client.Delete(ctx, prometheusRoute)
-		if err != nil {
+		if err != nil && !errors.IsNotFound(err) {
 			return v1.ResultFailed, err
 		}
 
 		prometheusService := model.GetPrometheusService(cr)
 		prometheusService.Name = model.PrometheusOldDefaultName
 		err = r.client.Delete(ctx, prometheusService)
-		if err != nil {
+		if err != nil && !errors.IsNotFound(err) {
 			return v1.ResultFailed, err
 		}
 
 		prometheusServiceAccount := model.GetPrometheusServiceAccount(cr)
 		prometheusServiceAccount.Name = model.PrometheusOldDefaultName
 		err = r.client.Delete(ctx, prometheusServiceAccount)
-		if err != nil {
+		if err != nil && !errors.IsNotFound(err) {
 			return v1.ResultFailed, err
 		}
 
 		prometheusClusterRole := model.GetPrometheusClusterRole(cr)
 		prometheusClusterRole.Name = model.PrometheusOldDefaultName
 		err = r.client.Delete(ctx, prometheusClusterRole)
-		if err != nil {
-			fmt.Println("fail delete Prometheus ClusterRole")
+		if err != nil && !errors.IsNotFound(err) {
 			return v1.ResultFailed, err
 		}
 
 		prometheusClusterRoleBinding := model.GetPrometheusClusterRoleBinding(cr)
 		prometheusClusterRoleBinding.Name = model.PrometheusOldDefaultName
 		err = r.client.Delete(ctx, prometheusClusterRoleBinding)
-		if err != nil {
-			fmt.Println("fail delete Prometheus ClusterRoleBinding")
+		if err != nil && !errors.IsNotFound(err) {
 			return v1.ResultFailed, err
 		}
 	}
@@ -96,7 +92,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, cr *v1.Observability, s *v1.
 			alertmanagerSecret := model.GetAlertmanagerSecret(cr)
 			alertmanagerSecret.Name = fmt.Sprintf("alertmanager-%s", model.AlertManagerOldDefaultName)
 			err := r.client.Delete(ctx, alertmanagerSecret)
-			if err != nil {
+			if err != nil && !errors.IsNotFound(err) {
 				return v1.ResultFailed, err
 			}
 		}
@@ -104,7 +100,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, cr *v1.Observability, s *v1.
 		alertManagerCr := model.GetAlertmanagerCr(cr)
 		alertManagerCr.Name = model.AlertManagerOldDefaultName
 		err := r.client.Delete(ctx, alertManagerCr)
-		if err != nil {
+		if err != nil && !errors.IsNotFound(err) {
 			return v1.ResultFailed, err
 		}
 
@@ -113,35 +109,35 @@ func (r *Reconciler) Reconcile(ctx context.Context, cr *v1.Observability, s *v1.
 		alertmanagerServiceAccount := model.GetAlertmanagerServiceAccount(cr)
 		alertmanagerServiceAccount.Name = model.AlertManagerOldDefaultName
 		err = r.client.Delete(ctx, alertmanagerServiceAccount)
-		if err != nil {
+		if err != nil && !errors.IsNotFound(err) {
 			return v1.ResultFailed, err
 		}
 
 		alertmanagerRoute := model.GetAlertmanagerRoute(cr)
 		alertmanagerRoute.Name = model.AlertManagerOldDefaultName
 		err = r.client.Delete(ctx, alertmanagerRoute)
-		if err != nil {
+		if err != nil && !errors.IsNotFound(err) {
 			return v1.ResultFailed, err
 		}
 
 		alertmanagerService := model.GetAlertmanagerService(cr)
 		alertmanagerService.Name = model.AlertManagerOldDefaultName
 		err = r.client.Delete(ctx, alertmanagerService)
-		if err != nil {
+		if err != nil && !errors.IsNotFound(err) {
 			return v1.ResultFailed, err
 		}
 
 		alertmanagerClusterRole := model.GetAlertmanagerClusterRole(cr)
 		alertmanagerClusterRole.Name = model.AlertManagerOldDefaultName
 		err = r.client.Delete(ctx, alertmanagerClusterRole)
-		if err != nil {
+		if err != nil && !errors.IsNotFound(err) {
 			return v1.ResultFailed, err
 		}
 
 		alertmanagerClusterRoleBinding := model.GetAlertmanagerClusterRoleBinding(cr)
 		alertmanagerClusterRoleBinding.Name = model.AlertManagerOldDefaultName
 		err = r.client.Delete(ctx, alertmanagerClusterRoleBinding)
-		if err != nil {
+		if err != nil && !errors.IsNotFound(err) {
 			return v1.ResultFailed, err
 		}
 	}
@@ -152,7 +148,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, cr *v1.Observability, s *v1.
 		grafanaCR := model.GetGrafanaCr(cr)
 		grafanaCR.Name = model.GrafanaOldDefaultName
 		err := r.client.Delete(ctx, grafanaCR)
-		if err != nil {
+		if err != nil && !errors.IsNotFound(err) {
 			return v1.ResultFailed, err
 		}
 
@@ -165,21 +161,21 @@ func (r *Reconciler) Reconcile(ctx context.Context, cr *v1.Observability, s *v1.
 		promtailServiceAccount := model.GetPromtailServiceAccount(cr)
 		promtailServiceAccount.Name = model.PromtailOldDefaultName
 		err := r.client.Delete(ctx, promtailServiceAccount)
-		if err != nil {
+		if err != nil && !errors.IsNotFound(err) {
 			return v1.ResultFailed, err
 		}
 
 		promtailClusterRole := model.GetPromtailClusterRole(cr)
 		promtailClusterRole.Name = model.PromtailOldDefaultName
 		err = r.client.Delete(ctx, promtailClusterRole)
-		if err != nil {
+		if err != nil && !errors.IsNotFound(err) {
 			return v1.ResultFailed, err
 		}
 
 		promtailClusterRoleBinding := model.GetPromtailClusterRoleBinding(cr)
 		promtailClusterRoleBinding.Name = model.PromtailOldDefaultName
 		err = r.client.Delete(ctx, promtailClusterRoleBinding)
-		if err != nil {
+		if err != nil && !errors.IsNotFound(err) {
 			return v1.ResultFailed, err
 		}
 	}

--- a/controllers/reconcilers/migration/resource_name_migration.go
+++ b/controllers/reconcilers/migration/resource_name_migration.go
@@ -3,11 +3,13 @@ package migration
 import (
 	"context"
 	"fmt"
+
 	"github.com/go-logr/logr"
 	v1 "github.com/redhat-developer/observability-operator/v3/api/v1"
 	"github.com/redhat-developer/observability-operator/v3/controllers/model"
 	"github.com/redhat-developer/observability-operator/v3/controllers/reconcilers"
 	v13 "k8s.io/api/apps/v1"
+
 	"k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -33,35 +35,151 @@ func (r *Reconciler) Reconcile(ctx context.Context, cr *v1.Observability, s *v1.
 		return v1.ResultSuccess, nil
 	}
 
-	prometheusCr := model.GetPrometheus(cr)
-	prometheusCr.Name = model.PrometheusOldDefaultName
+	//check if Prometheus resources needed to be migrated
+	if cr.Spec.PrometheusDefaultName == "" {
+		//remove Prometheus resources
+		prometheusCr := model.GetPrometheus(cr)
+		prometheusCr.Name = model.PrometheusOldDefaultName
 
-	err := r.client.Delete(ctx, prometheusCr)
-	if err != nil {
-		return v1.ResultFailed, err
+		err := r.client.Delete(ctx, prometheusCr)
+		if err != nil {
+			return v1.ResultFailed, err
+		}
+
+		r.waitForPrometheusToBeRemoved(ctx, cr, model.PrometheusOldDefaultName)
+
+		prometheusRoute := model.GetPrometheusRoute(cr)
+		prometheusRoute.Name = model.PrometheusOldDefaultName
+		err = r.client.Delete(ctx, prometheusRoute)
+		if err != nil {
+			return v1.ResultFailed, err
+		}
+
+		prometheusService := model.GetPrometheusService(cr)
+		prometheusService.Name = model.PrometheusOldDefaultName
+		err = r.client.Delete(ctx, prometheusService)
+		if err != nil {
+			return v1.ResultFailed, err
+		}
+
+		prometheusServiceAccount := model.GetPrometheusServiceAccount(cr)
+		prometheusServiceAccount.Name = model.PrometheusOldDefaultName
+		err = r.client.Delete(ctx, prometheusServiceAccount)
+		if err != nil {
+			return v1.ResultFailed, err
+		}
+
+		prometheusClusterRole := model.GetPrometheusClusterRole(cr)
+		prometheusClusterRole.Name = model.PrometheusOldDefaultName
+		err = r.client.Delete(ctx, prometheusClusterRole)
+		if err != nil {
+			fmt.Println("fail delete Prometheus ClusterRole")
+			return v1.ResultFailed, err
+		}
+
+		prometheusClusterRoleBinding := model.GetPrometheusClusterRoleBinding(cr)
+		prometheusClusterRoleBinding.Name = model.PrometheusOldDefaultName
+		err = r.client.Delete(ctx, prometheusClusterRoleBinding)
+		if err != nil {
+			fmt.Println("fail delete Prometheus ClusterRoleBinding")
+			return v1.ResultFailed, err
+		}
 	}
 
-	r.waitForPrometheusToBeRemoved(ctx, cr, model.PrometheusOldDefaultName)
+	//check if Alertmanager resources need migration
+	if cr.Spec.AlertManagerDefaultName == "" {
+		//remove Alertmanager resources
+		overrideSecret, _ := cr.HasAlertmanagerConfigSecret()
+		if !overrideSecret && !cr.ExternalSyncDisabled() {
+			alertmanagerSecret := model.GetAlertmanagerSecret(cr)
+			alertmanagerSecret.Name = fmt.Sprintf("alertmanager-%s", model.AlertManagerOldDefaultName)
+			err := r.client.Delete(ctx, alertmanagerSecret)
+			if err != nil {
+				return v1.ResultFailed, err
+			}
+		}
 
-	prometheusRoute := model.GetPrometheusRoute(cr)
-	prometheusRoute.Name = model.PrometheusOldDefaultName
-	err = r.client.Delete(ctx, prometheusRoute)
-	if err != nil {
-		return v1.ResultFailed, err
+		alertManagerCr := model.GetAlertmanagerCr(cr)
+		alertManagerCr.Name = model.AlertManagerOldDefaultName
+		err := r.client.Delete(ctx, alertManagerCr)
+		if err != nil {
+			return v1.ResultFailed, err
+		}
+
+		r.waitForAlertmanagerToBeRemoved(ctx, cr, model.AlertManagerOldDefaultName)
+
+		alertmanagerServiceAccount := model.GetAlertmanagerServiceAccount(cr)
+		alertmanagerServiceAccount.Name = model.AlertManagerOldDefaultName
+		err = r.client.Delete(ctx, alertmanagerServiceAccount)
+		if err != nil {
+			return v1.ResultFailed, err
+		}
+
+		alertmanagerRoute := model.GetAlertmanagerRoute(cr)
+		alertmanagerRoute.Name = model.AlertManagerOldDefaultName
+		err = r.client.Delete(ctx, alertmanagerRoute)
+		if err != nil {
+			return v1.ResultFailed, err
+		}
+
+		alertmanagerService := model.GetAlertmanagerService(cr)
+		alertmanagerService.Name = model.AlertManagerOldDefaultName
+		err = r.client.Delete(ctx, alertmanagerService)
+		if err != nil {
+			return v1.ResultFailed, err
+		}
+
+		alertmanagerClusterRole := model.GetAlertmanagerClusterRole(cr)
+		alertmanagerClusterRole.Name = model.AlertManagerOldDefaultName
+		err = r.client.Delete(ctx, alertmanagerClusterRole)
+		if err != nil {
+			return v1.ResultFailed, err
+		}
+
+		alertmanagerClusterRoleBinding := model.GetAlertmanagerClusterRoleBinding(cr)
+		alertmanagerClusterRoleBinding.Name = model.AlertManagerOldDefaultName
+		err = r.client.Delete(ctx, alertmanagerClusterRoleBinding)
+		if err != nil {
+			return v1.ResultFailed, err
+		}
 	}
 
-	prometheusService := model.GetPrometheusService(cr)
-	prometheusService.Name = model.PrometheusOldDefaultName
-	err = r.client.Delete(ctx, prometheusService)
-	if err != nil {
-		return v1.ResultFailed, err
+	//check if Grafana CR need migration
+	if cr.Spec.GrafanaDefaultName == "" {
+		//remove Grafana resources
+		grafanaCR := model.GetGrafanaCr(cr)
+		grafanaCR.Name = model.GrafanaOldDefaultName
+		err := r.client.Delete(ctx, grafanaCR)
+		if err != nil {
+			return v1.ResultFailed, err
+		}
+
+		r.waitForGrafanaToBeRemoved(ctx, cr)
 	}
 
-	prometheusServiceAccount := model.GetPrometheusServiceAccount(cr)
-	prometheusServiceAccount.Name = model.PrometheusOldDefaultName
-	err = r.client.Delete(ctx, prometheusServiceAccount)
-	if err != nil {
-		return v1.ResultFailed, err
+	//check if Promtail resources need migration
+	if !cr.ExternalSyncDisabled() || !cr.ObservatoriumDisabled() {
+		//remove Promtail rsources
+		promtailServiceAccount := model.GetPromtailServiceAccount(cr)
+		promtailServiceAccount.Name = model.PromtailOldDefaultName
+		err := r.client.Delete(ctx, promtailServiceAccount)
+		if err != nil {
+			return v1.ResultFailed, err
+		}
+
+		promtailClusterRole := model.GetPromtailClusterRole(cr)
+		promtailClusterRole.Name = model.PromtailOldDefaultName
+		err = r.client.Delete(ctx, promtailClusterRole)
+		if err != nil {
+			return v1.ResultFailed, err
+		}
+
+		promtailClusterRoleBinding := model.GetPromtailClusterRoleBinding(cr)
+		promtailClusterRoleBinding.Name = model.PromtailOldDefaultName
+		err = r.client.Delete(ctx, promtailClusterRoleBinding)
+		if err != nil {
+			return v1.ResultFailed, err
+		}
 	}
 
 	s.Migrated = true
@@ -81,6 +199,44 @@ func (r *Reconciler) waitForPrometheusToBeRemoved(ctx context.Context, cr *v1.Ob
 
 	for _, ss := range list.Items {
 		if ss.Name == fmt.Sprintf("prometheus-%s", prometheusName) {
+			return v1.ResultInProgress, nil
+		}
+	}
+
+	return v1.ResultSuccess, nil
+}
+
+func (r *Reconciler) waitForAlertmanagerToBeRemoved(ctx context.Context, cr *v1.Observability, alertmanagerName string) (v1.ObservabilityStageStatus, error) {
+	list := &v13.StatefulSetList{}
+	opts := &client.ListOptions{
+		Namespace: cr.Namespace,
+	}
+	err := r.client.List(ctx, list, opts)
+	if err != nil && !errors.IsNotFound(err) {
+		return v1.ResultFailed, err
+	}
+
+	for _, ss := range list.Items {
+		if ss.Name == fmt.Sprintf("prometheus-%s", alertmanagerName) {
+			return v1.ResultInProgress, nil
+		}
+	}
+
+	return v1.ResultSuccess, nil
+}
+
+func (r *Reconciler) waitForGrafanaToBeRemoved(ctx context.Context, cr *v1.Observability) (v1.ObservabilityStageStatus, error) {
+	list := &v13.DeploymentList{}
+	opts := &client.ListOptions{
+		Namespace: cr.Namespace,
+	}
+	err := r.client.List(ctx, list, opts)
+	if err != nil && !errors.IsNotFound(err) {
+		return v1.ResultFailed, err
+	}
+
+	for _, ss := range list.Items {
+		if ss.Name == "grafana-deployment" {
 			return v1.ResultInProgress, nil
 		}
 	}

--- a/controllers/utils/reconciler_utils.go
+++ b/controllers/utils/reconciler_utils.go
@@ -141,7 +141,7 @@ func WaitForAlertmanagerToBeRemoved(ctx context.Context, cr *v1.Observability, c
 	alertmanager := model.GetAlertmanagerCr(cr)
 
 	for _, ss := range list.Items {
-		if ss.Name == fmt.Sprintf("prometheus-%s", alertmanager.Name) {
+		if ss.Name == fmt.Sprintf("alertmanager-%s", alertmanager.Name) {
 			return v1.ResultInProgress, nil
 		}
 	}

--- a/controllers/utils/reconciler_utils.go
+++ b/controllers/utils/reconciler_utils.go
@@ -4,11 +4,16 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/base64"
+	"fmt"
 
 	v13 "github.com/openshift/api/config/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	v12 "github.com/operator-framework/api/pkg/operators/v1"
-	v1 "k8s.io/api/core/v1"
+	v1 "github.com/redhat-developer/observability-operator/v3/api/v1"
+	"github.com/redhat-developer/observability-operator/v3/controllers/model"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -73,7 +78,7 @@ func IsRouteReady(route *routev1.Route) bool {
 	for _, ingress := range route.Status.Ingress {
 		for _, condition := range ingress.Conditions {
 			// A successful route will have the admitted condition type as true
-			if condition.Type == routev1.RouteAdmitted && condition.Status != v1.ConditionTrue {
+			if condition.Type == routev1.RouteAdmitted && condition.Status != corev1.ConditionTrue {
 				return false
 			}
 		}
@@ -102,4 +107,65 @@ func GenerateRandomBytes(n int) []byte {
 func GenerateRandomString(s int) string {
 	b := GenerateRandomBytes(s)
 	return base64.URLEncoding.EncodeToString(b)
+}
+
+func WaitForGrafanaToBeRemoved(ctx context.Context, cr *v1.Observability, client k8sclient.Client) (v1.ObservabilityStageStatus, error) {
+	list := &appsv1.DeploymentList{}
+	opts := &k8sclient.ListOptions{
+		Namespace: cr.Namespace,
+	}
+	err := client.List(ctx, list, opts)
+	if err != nil && !errors.IsNotFound(err) {
+		return v1.ResultFailed, err
+	}
+
+	for _, ss := range list.Items {
+		if ss.Name == "grafana-deployment" {
+			return v1.ResultInProgress, nil
+		}
+	}
+
+	return v1.ResultSuccess, nil
+}
+
+func WaitForAlertmanagerToBeRemoved(ctx context.Context, cr *v1.Observability, client k8sclient.Client) (v1.ObservabilityStageStatus, error) {
+	list := &appsv1.StatefulSetList{}
+	opts := &k8sclient.ListOptions{
+		Namespace: cr.Namespace,
+	}
+	err := client.List(ctx, list, opts)
+	if err != nil && !errors.IsNotFound(err) {
+		return v1.ResultFailed, err
+	}
+
+	alertmanager := model.GetAlertmanagerCr(cr)
+
+	for _, ss := range list.Items {
+		if ss.Name == fmt.Sprintf("prometheus-%s", alertmanager.Name) {
+			return v1.ResultInProgress, nil
+		}
+	}
+
+	return v1.ResultSuccess, nil
+}
+
+func WaitForPrometheusToBeRemoved(ctx context.Context, cr *v1.Observability, client k8sclient.Client) (v1.ObservabilityStageStatus, error) {
+	list := &appsv1.StatefulSetList{}
+	opts := &k8sclient.ListOptions{
+		Namespace: cr.Namespace,
+	}
+	err := client.List(ctx, list, opts)
+	if err != nil && !errors.IsNotFound(err) {
+		return v1.ResultFailed, err
+	}
+
+	prom := model.GetPrometheus(cr)
+
+	for _, ss := range list.Items {
+		if ss.Name == fmt.Sprintf("prometheus-%s", prom.Name) {
+			return v1.ResultInProgress, nil
+		}
+	}
+
+	return v1.ResultSuccess, nil
 }

--- a/controllers/utils/reconciler_utils_test.go
+++ b/controllers/utils/reconciler_utils_test.go
@@ -1,11 +1,18 @@
 package utils
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
 	routev1 "github.com/openshift/api/route/v1"
-	v1 "k8s.io/api/core/v1"
+	v1 "github.com/redhat-developer/observability-operator/v3/api/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 const (
@@ -13,6 +20,27 @@ const (
 	InvalidVersionString = "invalid"
 )
 
+var (
+	testNamespace        = "test-namespace"
+	emptyStatefulSetList = &appsv1.StatefulSetList{
+		Items: []appsv1.StatefulSet{},
+	}
+	emptyDeploymentList = &appsv1.DeploymentList{
+		Items: []appsv1.Deployment{},
+	}
+)
+
+func buildObservabilityCR(modifyFn func(obsCR *v1.Observability)) *v1.Observability {
+	obsCR := &v1.Observability{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNamespace,
+		},
+	}
+	if modifyFn != nil {
+		modifyFn(obsCR)
+	}
+	return obsCR
+}
 func TestReconcilerUtils_IsRouteReady(t *testing.T) {
 	type args struct {
 		route *routev1.Route
@@ -39,7 +67,7 @@ func TestReconcilerUtils_IsRouteReady(t *testing.T) {
 								Conditions: []routev1.RouteIngressCondition{
 									{
 										Type:   routev1.RouteAdmitted,
-										Status: v1.ConditionFalse,
+										Status: corev1.ConditionFalse,
 									},
 								},
 							},
@@ -58,7 +86,7 @@ func TestReconcilerUtils_IsRouteReady(t *testing.T) {
 								Conditions: []routev1.RouteIngressCondition{
 									{
 										Type:   routev1.RouteAdmitted,
-										Status: v1.ConditionUnknown,
+										Status: corev1.ConditionUnknown,
 									},
 								},
 							},
@@ -77,7 +105,7 @@ func TestReconcilerUtils_IsRouteReady(t *testing.T) {
 								Conditions: []routev1.RouteIngressCondition{
 									{
 										Type:   routev1.RouteAdmitted,
-										Status: v1.ConditionTrue,
+										Status: corev1.ConditionTrue,
 									},
 								},
 							},
@@ -89,11 +117,189 @@ func TestReconcilerUtils_IsRouteReady(t *testing.T) {
 		},
 	}
 
-	g := NewWithT(t)
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := IsRouteReady(tt.args.route)
-			g.Expect(result).To(Equal(tt.want))
+		test := tt
+		t.Run(test.name, func(t *testing.T) {
+			g := NewWithT(t)
+			result := IsRouteReady(test.args.route)
+			g.Expect(result).To(Equal(test.want))
+		})
+	}
+}
+
+func TestReconcilerUtils_WaitForGrafanaToBeRemoved(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = appsv1.SchemeBuilder.AddToScheme(scheme)
+	_ = v1.SchemeBuilder.AddToScheme(scheme)
+	grafanaDeployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "grafana-deployment",
+			Namespace: "test-namespace",
+		},
+	}
+	grafanaDeploymentList := &appsv1.DeploymentList{
+		Items: []appsv1.Deployment{*grafanaDeployment},
+	}
+
+	type args struct {
+		ctx        context.Context
+		cr         *v1.Observability
+		fakeClient k8sclient.Client
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		want    v1.ObservabilityStageStatus
+		wantErr bool
+	}{
+		{
+			name: "return in progress status when Grafana deployment present",
+			args: args{
+				ctx:        context.TODO(),
+				cr:         buildObservabilityCR(nil),
+				fakeClient: fakeclient.NewFakeClientWithScheme(scheme, grafanaDeploymentList),
+			},
+			want:    v1.ResultInProgress,
+			wantErr: false,
+		},
+		{
+			name: "return success status when Grafana deployment NOT present",
+			args: args{
+				ctx:        context.TODO(),
+				cr:         buildObservabilityCR(nil),
+				fakeClient: fakeclient.NewFakeClientWithScheme(scheme, emptyDeploymentList),
+			},
+			want:    v1.ResultSuccess,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		test := tt
+		t.Run(test.name, func(t *testing.T) {
+			g := NewWithT(t)
+			status, err := WaitForGrafanaToBeRemoved(test.args.ctx, test.args.cr, test.args.fakeClient)
+			g.Expect(err != nil).To(Equal(test.wantErr))
+			g.Expect(status).To(Equal(test.want))
+		})
+	}
+}
+
+func TestReconcilerUtils_WaitForAlertmanagerToBeRemoved(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = appsv1.SchemeBuilder.AddToScheme(scheme)
+	_ = v1.SchemeBuilder.AddToScheme(scheme)
+	alertmanagerStatefulSet := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "alertmanager-observability-alertmanager",
+			Namespace: "test-namespace",
+		},
+	}
+	alertmanagerStatefulSetList := &appsv1.StatefulSetList{
+		Items: []appsv1.StatefulSet{*alertmanagerStatefulSet},
+	}
+
+	type args struct {
+		ctx        context.Context
+		cr         *v1.Observability
+		fakeClient k8sclient.Client
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		want    v1.ObservabilityStageStatus
+		wantErr bool
+	}{
+		{
+			name: "return in progress status when Alertmanager StatefulSet present",
+			args: args{
+				ctx:        context.TODO(),
+				cr:         buildObservabilityCR(nil),
+				fakeClient: fakeclient.NewFakeClientWithScheme(scheme, alertmanagerStatefulSetList),
+			},
+			want:    v1.ResultInProgress,
+			wantErr: false,
+		},
+		{
+			name: "return success status when Alertmanager StatefulSet NOT present",
+			args: args{
+				ctx:        context.TODO(),
+				cr:         buildObservabilityCR(nil),
+				fakeClient: fakeclient.NewFakeClientWithScheme(scheme, emptyStatefulSetList),
+			},
+			want:    v1.ResultSuccess,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		test := tt
+		t.Run(test.name, func(t *testing.T) {
+			g := NewWithT(t)
+			status, err := WaitForAlertmanagerToBeRemoved(test.args.ctx, test.args.cr, test.args.fakeClient)
+			g.Expect(err != nil).To(Equal(test.wantErr))
+			g.Expect(status).To(Equal(test.want))
+		})
+	}
+}
+
+func TestReconcilerUtils_WaitForPrometheusToBeRemoved(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = appsv1.SchemeBuilder.AddToScheme(scheme)
+	_ = v1.SchemeBuilder.AddToScheme(scheme)
+	prometheusStatefulSet := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "prometheus-observability-prometheus",
+			Namespace: "test-namespace",
+		},
+	}
+	prometheusStatefulSetList := &appsv1.StatefulSetList{
+		Items: []appsv1.StatefulSet{*prometheusStatefulSet},
+	}
+
+	type args struct {
+		ctx        context.Context
+		cr         *v1.Observability
+		fakeClient k8sclient.Client
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		want    v1.ObservabilityStageStatus
+		wantErr bool
+	}{
+		{
+			name: "return in progress status when Prometheus StatefulSet present",
+			args: args{
+				ctx:        context.TODO(),
+				cr:         buildObservabilityCR(nil),
+				fakeClient: fakeclient.NewFakeClientWithScheme(scheme, prometheusStatefulSetList),
+			},
+			want:    v1.ResultInProgress,
+			wantErr: false,
+		},
+		{
+			name: "return success status when Prometheus StatefulSet NOT present",
+			args: args{
+				ctx:        context.TODO(),
+				cr:         buildObservabilityCR(nil),
+				fakeClient: fakeclient.NewFakeClientWithScheme(scheme, emptyStatefulSetList),
+			},
+			want:    v1.ResultSuccess,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		test := tt
+		t.Run(test.name, func(t *testing.T) {
+			g := NewWithT(t)
+			status, err := WaitForPrometheusToBeRemoved(test.args.ctx, test.args.cr, test.args.fakeClient)
+			g.Expect(err != nil).To(Equal(test.wantErr))
+			g.Expect(status).To(Equal(test.want))
 		})
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/redhat-developer/observability-operator/v3
 go 1.16
 
 require (
+	github.com/blang/semver v3.5.1+incompatible
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v1.2.3
 	github.com/goccy/go-yaml v1.9.5
@@ -24,7 +25,6 @@ require (
 
 require (
 	github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d // indirect
-	github.com/blang/semver v3.5.1+incompatible
 	github.com/bshuster-repo/logrus-logstash-hook v1.0.2 // indirect
 	github.com/bugsnag/bugsnag-go v2.1.2+incompatible // indirect
 	github.com/bugsnag/panicwrap v1.3.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2101,6 +2101,8 @@ go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/
 go.uber.org/multierr v1.3.0/go.mod h1:VgVr7evmIr6uPjLBxg28wmKNXyqE9akIJ5XnfpiKl+4=
 go.uber.org/multierr v1.4.0/go.mod h1:VgVr7evmIr6uPjLBxg28wmKNXyqE9akIJ5XnfpiKl+4=
 go.uber.org/multierr v1.5.0/go.mod h1:FeouvMocqHpRaaGuG9EjoKcStLC43Zu/fmqdUMPcKYU=
+go.uber.org/multierr v1.6.0 h1:y6IPFStTAIT5Ytl7/XYmHvzXQ7S3g/IeZW9hyZ5thw4=
+go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9iU=
 go.uber.org/tools v0.0.0-20190618225709-2cfd321de3ee h1:0mgffUl7nfd+FpvXMVz4IDEaUSmT1ysygQC7qYo7sG4=
 go.uber.org/tools v0.0.0-20190618225709-2cfd321de3ee/go.mod h1:vJERXedbb3MVM5f9Ejo0C68/HhF8uaILCdgjnY+goOA=
 go.uber.org/zap v1.9.1/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
@@ -2190,6 +2192,8 @@ golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzB
 golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.4.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.4.1/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.2 h1:Gz96sIWK3OalVv/I/qNygP42zyoKp3xptRVCWRFEBvo=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20170114055629-f2499483f923/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -2535,6 +2539,9 @@ golang.org/x/tools v0.0.0-20201208233053-a543418bbed2/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210105154028-b0ab187a4818/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
+golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
+golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
+golang.org/x/tools v0.1.2/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.5 h1:ouewzE6p+/VEB31YYnTbEJdi8pFqKp4P4n85vwo3DHA=
 golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.6-0.20210820212750-d4cc65f0b2ff h1:VX/uD7MK0AHXGiScH3fsieUQUcpmRERPDYtqZdJnA+Q=
@@ -2775,6 +2782,8 @@ gopkg.in/yaml.v3 v3.0.0-20191120175047-4206685974f2/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20200603094226-e3079894b1e8/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
+gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=

--- a/go.sum
+++ b/go.sum
@@ -890,6 +890,7 @@ github.com/golang/mock v1.3.1/go.mod h1:sBzyDLLjw3U8JLTeZvSv8jJB+tU5PVekmnlKIyFU
 github.com/golang/mock v1.4.0/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/mock v1.4.1/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/mock v1.4.3/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
+github.com/golang/mock v1.4.4 h1:l75CXGRSwbaYNpl/Z2X1XIIAMSCquvXgpVZDhwEIJsc=
 github.com/golang/mock v1.4.4/go.mod h1:l3mdAwkq5BuhzHwde/uurv3sEJeZMXNpwsxVWU71h+4=
 github.com/golang/mock v1.5.0 h1:jlYHihg//f7RRwuPfptm04yp4s7O6Kw8EZiVYIGcH0g=
 github.com/golang/mock v1.5.0/go.mod h1:CWnOUgYIOo4TcNZ0wHX3YZCqsaM1I1Jvs6v3mP3KVu8=
@@ -1282,6 +1283,7 @@ github.com/kr/pty v1.0.0/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5 h1:hyz3dwM5QLc1Rfoz4FuWJQG5BN7tc6K1MndAUnGpQr4=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
@@ -1858,6 +1860,7 @@ github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasO
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
+github.com/spf13/afero v1.2.2 h1:5jhuqJyZCZf2JRofRvN/nIFgIWNzPa3/Vz8mYylgbWc=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/afero v1.6.0 h1:xoax2sJ2DT8S8xA2paPFjDCScCNeWsg75VG0DLRreiY=
 github.com/spf13/afero v1.6.0/go.mod h1:Ai8FlHk4v/PARR026UzYexafAt9roJ7LcLMAmO6Z93I=
@@ -1869,6 +1872,7 @@ github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3
 github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tLCHU=
 github.com/spf13/cobra v0.0.6/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
 github.com/spf13/cobra v0.0.7/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
+github.com/spf13/cobra v1.0.0 h1:6m/oheQuQ13N9ks4hubMG6BnvwOeaJrqSPLahSnczz8=
 github.com/spf13/cobra v1.0.0/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
 github.com/spf13/cobra v1.2.1 h1:+KmjbUw1hriSNMF55oPrkZcb27aECyrj8V2ytv7kWDw=
 github.com/spf13/cobra v1.2.1/go.mod h1:ExllRjgxM/piMAM+3tAZvg8fsklGAf3tPfi+i8t68Nk=
@@ -2097,8 +2101,6 @@ go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/
 go.uber.org/multierr v1.3.0/go.mod h1:VgVr7evmIr6uPjLBxg28wmKNXyqE9akIJ5XnfpiKl+4=
 go.uber.org/multierr v1.4.0/go.mod h1:VgVr7evmIr6uPjLBxg28wmKNXyqE9akIJ5XnfpiKl+4=
 go.uber.org/multierr v1.5.0/go.mod h1:FeouvMocqHpRaaGuG9EjoKcStLC43Zu/fmqdUMPcKYU=
-go.uber.org/multierr v1.6.0 h1:y6IPFStTAIT5Ytl7/XYmHvzXQ7S3g/IeZW9hyZ5thw4=
-go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9iU=
 go.uber.org/tools v0.0.0-20190618225709-2cfd321de3ee h1:0mgffUl7nfd+FpvXMVz4IDEaUSmT1ysygQC7qYo7sG4=
 go.uber.org/tools v0.0.0-20190618225709-2cfd321de3ee/go.mod h1:vJERXedbb3MVM5f9Ejo0C68/HhF8uaILCdgjnY+goOA=
 go.uber.org/zap v1.9.1/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
@@ -2174,6 +2176,7 @@ golang.org/x/lint v0.0.0-20190909230951-414d861bb4ac/go.mod h1:6SW0HCj/g11FgYtHl
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f/go.mod h1:5qLYkcX4OjUUV8bRuDixDT3tpyyb+LUpUlRWLxfhWrs=
 golang.org/x/lint v0.0.0-20200130185559-910be7a94367/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
+golang.org/x/lint v0.0.0-20200302205851-738671d3881b h1:Wh+f8QHJXR411sJR8/vRBTZ7YapZaRvUcLFFJhusH0k=
 golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/lint v0.0.0-20201208152925-83fdc39ff7b5/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 h1:VLliZ0d+/avPrXXH+OakdXhpJuEoBZuwh1m2j7U6Iug=
@@ -2187,8 +2190,6 @@ golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzB
 golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.4.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.4.1/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.2 h1:Gz96sIWK3OalVv/I/qNygP42zyoKp3xptRVCWRFEBvo=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20170114055629-f2499483f923/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -2534,9 +2535,7 @@ golang.org/x/tools v0.0.0-20201208233053-a543418bbed2/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210105154028-b0ab187a4818/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
-golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
-golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
-golang.org/x/tools v0.1.2/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
+golang.org/x/tools v0.1.5 h1:ouewzE6p+/VEB31YYnTbEJdi8pFqKp4P4n85vwo3DHA=
 golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.6-0.20210820212750-d4cc65f0b2ff h1:VX/uD7MK0AHXGiScH3fsieUQUcpmRERPDYtqZdJnA+Q=
 golang.org/x/tools v0.1.6-0.20210820212750-d4cc65f0b2ff/go.mod h1:YD9qOF0M9xpSpdWTBbzEl5e/RnCefISl8E5Noe10jFM=
@@ -2717,6 +2716,7 @@ gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQ
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
@@ -2775,8 +2775,6 @@ gopkg.in/yaml.v3 v3.0.0-20191120175047-4206685974f2/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20200603094226-e3079894b1e8/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
-gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=


### PR DESCRIPTION
Migrating all the Kafka specific resources to neutral names. This is achieved by adding a new phase that runs first and deletes any resources (Prometheus CR, service, service account, route) with the old name.

Then continues with the regular phases to restore the resources with the new names.