### PR TITLE
Fallback to bearer token if no secret exists

### DIFF
--- a/bundle/manifests/observability-operator-federation-reader_rbac.authorization.k8s.io_v1_rolebinding.yaml
+++ b/bundle/manifests/observability-operator-federation-reader_rbac.authorization.k8s.io_v1_rolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: operator-federation-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-monitoring-view
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: system

--- a/controllers/model/prometheus_resources.go
+++ b/controllers/model/prometheus_resources.go
@@ -139,7 +139,7 @@ func GetPrometheusRoute(cr *v1.Observability) *routev1.Route {
 	}
 }
 
-func GetFederationConfig(user, pass string, patterns []string) ([]byte, error) {
+func GetFederationConfigBasicAuth(user, pass string, patterns []string) ([]byte, error) {
 	const config = `
 - job_name: openshift-monitoring-federation
   honor_labels: true
@@ -177,6 +177,45 @@ func GetFederationConfig(user, pass string, patterns []string) ([]byte, error) {
 	}{
 		User:     user,
 		Pass:     pass,
+		Patterns: strings.Join(patterns, ","),
+	})
+
+	return buffer.Bytes(), err
+}
+
+func GetFederationConfigBearerToken(patterns []string) ([]byte, error) {
+	fmt.Println("gotFedconfig")
+	const config = `
+- job_name: openshift-monitoring-federation
+  honor_labels: true
+  kubernetes_sd_configs:
+    - role: service
+      namespaces:
+        names:
+          - openshift-monitoring
+  scrape_interval: 120s
+  scrape_timeout: 60s
+  metrics_path: /federate
+  relabel_configs:
+    - action: keep
+      source_labels: [ '__meta_kubernetes_service_name' ]
+      regex: prometheus-k8s
+    - action: keep
+      source_labels: [ '__meta_kubernetes_service_port_name' ]
+      regex: web
+  params:
+    match[]: [{{ .Patterns }}]
+  scheme: https
+  bearer_token_file: "/var/run/secrets/kubernetes.io/serviceaccount/token"
+  tls_config:
+    insecure_skip_verify: true
+`
+
+	template := t.Must(t.New("template").Parse(config))
+	var buffer bytes.Buffer
+	err := template.Execute(&buffer, struct {
+		Patterns string
+	}{
 		Patterns: strings.Join(patterns, ","),
 	})
 

--- a/controllers/model/prometheus_resources.go
+++ b/controllers/model/prometheus_resources.go
@@ -184,7 +184,6 @@ func GetFederationConfigBasicAuth(user, pass string, patterns []string) ([]byte,
 }
 
 func GetFederationConfigBearerToken(patterns []string) ([]byte, error) {
-	fmt.Println("gotFedconfig")
 	const config = `
 - job_name: openshift-monitoring-federation
   honor_labels: true

--- a/controllers/model/prometheus_resources.go
+++ b/controllers/model/prometheus_resources.go
@@ -139,50 +139,6 @@ func GetPrometheusRoute(cr *v1.Observability) *routev1.Route {
 	}
 }
 
-func GetFederationConfigBasicAuth(user, pass string, patterns []string) ([]byte, error) {
-	const config = `
-- job_name: openshift-monitoring-federation
-  honor_labels: true
-  kubernetes_sd_configs:
-    - role: service
-      namespaces:
-        names:
-          - openshift-monitoring
-  scrape_interval: 120s
-  scrape_timeout: 60s
-  metrics_path: /federate
-  relabel_configs:
-    - action: keep
-      source_labels: [ '__meta_kubernetes_service_name' ]
-      regex: prometheus-k8s
-    - action: keep
-      source_labels: [ '__meta_kubernetes_service_port_name' ]
-      regex: web
-  params:
-    match[]: [{{ .Patterns }}]
-  scheme: https
-  tls_config:
-    insecure_skip_verify: true
-  basic_auth:
-    username: {{ .User }}
-    password: {{ .Pass }}
-`
-
-	template := t.Must(t.New("template").Parse(config))
-	var buffer bytes.Buffer
-	err := template.Execute(&buffer, struct {
-		User     string
-		Pass     string
-		Patterns string
-	}{
-		User:     user,
-		Pass:     pass,
-		Patterns: strings.Join(patterns, ","),
-	})
-
-	return buffer.Bytes(), err
-}
-
 func GetFederationConfigBearerToken(patterns []string) ([]byte, error) {
 	const config = `
 - job_name: openshift-monitoring-federation

--- a/controllers/model/prometheus_resources_test.go
+++ b/controllers/model/prometheus_resources_test.go
@@ -20,34 +20,7 @@ var (
 	defaultPrometheusName              = "kafka-prometheus"
 	serviceAccountPrometheusAnnotation = map[string]string{"serviceaccounts.openshift.io/oauth-redirectreference.primary": "{\"kind\":\"OAuthRedirectReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"Route\",\"name\":\"kafka-prometheus\"}}"}
 	testPattern                        = []string{"test1", "test2"}
-	testFederationConfigBasicAuth      = `
-- job_name: openshift-monitoring-federation
-  honor_labels: true
-  kubernetes_sd_configs:
-    - role: service
-      namespaces:
-        names:
-          - openshift-monitoring
-  scrape_interval: 120s
-  scrape_timeout: 60s
-  metrics_path: /federate
-  relabel_configs:
-    - action: keep
-      source_labels: [ '__meta_kubernetes_service_name' ]
-      regex: prometheus-k8s
-    - action: keep
-      source_labels: [ '__meta_kubernetes_service_port_name' ]
-      regex: web
-  params:
-    match[]: [test1,test2]
-  scheme: https
-  tls_config:
-    insecure_skip_verify: true
-  basic_auth:
-    username: testuser
-    password: testpass
-`
-	testFederationConfigBearerToken = `
+	testFederationConfigBearerToken    = `
 - job_name: openshift-monitoring-federation
   honor_labels: true
   kubernetes_sd_configs:
@@ -72,7 +45,6 @@ var (
   tls_config:
     insecure_skip_verify: true
 `
-	configAsByteArrayBasicAuth   = []byte(testFederationConfigBasicAuth)
 	configAsByteArrayBearerToken = []byte(testFederationConfigBearerToken)
 	testRepoIndexes              = []v1.RepositoryIndex{
 		{
@@ -503,41 +475,6 @@ func TestPrometheusResources_GetPrometheusRoute(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := GetPrometheusRoute(tt.args.cr)
-			Expect(result).To(Equal(tt.want))
-		})
-	}
-}
-
-func TestPrometheusResources_GetFederationConfigBasicAuth(t *testing.T) {
-	type args struct {
-		user     string
-		pass     string
-		patterns []string
-	}
-
-	tests := []struct {
-		name    string
-		args    args
-		wantErr bool
-		want    []byte
-	}{
-		{
-			name: "returns correct federation config with no error",
-			args: args{
-				user:     "testuser",
-				pass:     "testpass",
-				patterns: testPattern,
-			},
-			wantErr: false,
-			want:    configAsByteArrayBasicAuth,
-		},
-	}
-
-	RegisterTestingT(t)
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result, err := GetFederationConfigBasicAuth(tt.args.user, tt.args.pass, tt.args.patterns)
-			Expect(err != nil).To(Equal(tt.wantErr))
 			Expect(result).To(Equal(tt.want))
 		})
 	}

--- a/controllers/reconcilers/configuration/prometheus.go
+++ b/controllers/reconcilers/configuration/prometheus.go
@@ -2,7 +2,6 @@ package configuration
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"regexp"
 
@@ -26,20 +25,6 @@ const (
 	PrometheusBaseImage = "quay.io/prometheus/prometheus"
 	PrometheusRetention = "45d"
 )
-
-type datasourceSecureData struct {
-	BasicAuthPassword string `json:"basicAuthPassword,omitempty"`
-}
-type datasource struct {
-	BasicAuthUser     string `json:"basicAuthUser"`
-	BasicAuthPassword string `json:"basicAuthPassword,omitempty"`
-	//secureJsonData is used in grafana-datasources-v2 secret
-	SecureJsonData datasourceSecureData `json:"secureJsonData,omitempty"`
-}
-
-type datasources struct {
-	Sources []datasource `json:"datasources"`
-}
 
 func (r *Reconciler) fetchFederationConfigs(cr *v1.Observability, indexes []v1.RepositoryIndex) ([]string, error) {
 	var result []string
@@ -109,18 +94,7 @@ func (r *Reconciler) createBlackBoxConfig(cr *v1.Observability, ctx context.Cont
 // This expects the aggregation of all federation configs across all indexes
 func (r *Reconciler) createAdditionalScrapeConfigSecret(cr *v1.Observability, ctx context.Context, patterns []string) error {
 	secret := model.GetPrometheusAdditionalScrapeConfig(cr)
-
-	user, password, _ := r.getOpenshiftMonitoringCredentials(ctx)
-
-	var federationConfig []byte
-	var err error
-	// If we haven't found a user or password from a grafana secret fall back to using bearer token
-	if user != "" && password != "" {
-		federationConfig, err = model.GetFederationConfigBasicAuth(user, password, patterns)
-	} else {
-		federationConfig, err = model.GetFederationConfigBearerToken(patterns)
-	}
-
+	federationConfig, err := model.GetFederationConfigBearerToken(patterns)
 	if err != nil {
 		return err
 	}
@@ -138,49 +112,6 @@ func (r *Reconciler) createAdditionalScrapeConfigSecret(cr *v1.Observability, ct
 	}
 
 	return nil
-}
-
-func (r *Reconciler) getOpenshiftMonitoringCredentials(ctx context.Context) (string, string, error) {
-	secret, err := r.getGrafanaDatasourcesSecret(ctx)
-	if err != nil {
-		r.logger.Info("unable to find grafana datasources secret")
-		return "", "", nil
-	}
-
-	// It says yaml but it's actually json
-	j := secret.Data["prometheus.yaml"]
-	ds := &datasources{}
-	err = json.Unmarshal(j, ds)
-	if err != nil {
-		return "", "", nil
-	}
-
-	if secret.Name == "grafana-datasources" {
-		return ds.Sources[0].BasicAuthUser, ds.Sources[0].BasicAuthPassword, nil
-	}
-	return ds.Sources[0].BasicAuthUser, ds.Sources[0].SecureJsonData.BasicAuthPassword, nil
-}
-
-// grafana-datasources secret can have 2 different names/structures so need to check for correct secret
-func (r *Reconciler) getGrafanaDatasourcesSecret(ctx context.Context) (*kv1.Secret, error) {
-	secret := &kv1.Secret{}
-	selector := &client.ObjectKey{
-		Namespace: "openshift-monitoring",
-		Name:      "grafana-datasources-v2",
-	}
-
-	//check if grafana-datasources-v2 exists
-	err := r.client.Get(ctx, *selector, secret)
-	if err != nil {
-		//check if grafana-datasources exists
-		selector.Name = "grafana-datasources"
-		err = r.client.Get(ctx, *selector, secret)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	return secret, nil
 }
 
 func (r *Reconciler) getRemoteWriteIndex(index v1.RepositoryIndex) (*v1.RemoteWriteIndex, error) {


### PR DESCRIPTION
This PR leaves the current behaviour as-is and adds a fallback for when the operator cannot find either grafana secret to use a bearer_token_file to access the cluster prometheus.

To operator-federation-reader role is to allow the operator to access the cluster prometheus through bearer token.

I've tested using grafana-datasources-v2 and deleting the secret and confirming the scrape config then correctly includes the bearer_token_file var.

Verification:

1. Install the operator
2. In a separate window continually delete the grafana-datasource-v2 secret
3. Verify that the bearer_token_file var exists in the additional-scrape-config.yaml configmap