### PR TITLE
Update ubi image and go toolset version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi8/go-toolset:1.16.7 as builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.17.10 as builder
 
 USER root
 
@@ -22,7 +22,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager 
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
 
 WORKDIR /
 COPY --from=builder /workspace/manager .


### PR DESCRIPTION
To resolve image vulnerabilities, the following versions are updated in Dockerfile:

- ubi-minimal:8.5 => ubi-minimal:8.6
- go-toolset:1.16.7 => go-toolset:1.17.10