### PR TITLE
Add pod eviction annotations to relevant Observability pods

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -68,6 +68,7 @@ rules:
   - config.openshift.io
   resources:
   - clusterversions
+  - infrastructures
   verbs:
   - get
   - list

--- a/controllers/observability_controller.go
+++ b/controllers/observability_controller.go
@@ -56,7 +56,7 @@ type ObservabilityReconciler struct {
 // +kubebuilder:rbac:groups=observability.redhat.com,resources=observabilities/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=corev1,resources=configmaps,verbs=get;list;create;update;patch;delete
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=podmonitors;alertmanagers;prometheuses;prometheuses/finalizers;alertmanagers/finalizers;servicemonitors;prometheusrules;thanosrulers;thanosrulers/finalizers,verbs=get;list;create;update;patch;delete;watch
-// +kubebuilder:rbac:groups=config.openshift.io,resources=clusterversions,verbs=get;list;watch
+// +kubebuilder:rbac:groups=config.openshift.io,resources=clusterversions;infrastructures,verbs=get;list;watch
 // +kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,resourceNames=privileged,verbs=use
 // +kubebuilder:rbac:groups=integreatly.org,resources=grafanas;grafanadashboards;grafanadatasources,verbs=get;list;create;update;delete;watch
 // +kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=get;list;create;update;delete;watch

--- a/controllers/reconcilers/configuration/grafana.go
+++ b/controllers/reconcilers/configuration/grafana.go
@@ -127,6 +127,9 @@ func (r *Reconciler) reconcileGrafanaCr(ctx context.Context, cr *v1.Observabilit
 			Deployment: &v1alpha1.GrafanaDeployment{
 				Replicas:          1,
 				PriorityClassName: model.ObservabilityPriorityClassName,
+				Annotations: map[string]string{
+					"cluster-autoscaler.kubernetes.io/safe-to-evict": "true",
+				},
 			},
 			Resources: model.GetGrafanaResourceRequirement(cr),
 		}

--- a/controllers/reconcilers/configuration/prometheus.go
+++ b/controllers/reconcilers/configuration/prometheus.go
@@ -348,6 +348,11 @@ func (r *Reconciler) reconcilePrometheus(ctx context.Context, cr *v1.Observabili
 		}
 
 		prometheus.Spec = prometheusv1.PrometheusSpec{
+			PodMetadata: &prometheusv1.EmbeddedObjectMetadata{
+				Annotations: map[string]string{
+					"cluster-autoscaler.kubernetes.io/safe-to-evict": "true",
+				},
+			},
 			// Custom Prometheus version
 			Image:   &image,
 			Version: model.GetPrometheusVersion(cr),
@@ -416,7 +421,7 @@ func (r *Reconciler) reconcilePrometheus(ctx context.Context, cr *v1.Observabili
 	return nil
 }
 
-//construct Prometheus storage spec with either default or override value from resources
+// construct Prometheus storage spec with either default or override value from resources
 func getPrometheusStorageSpecHelper(cr *v1.Observability, indexes []v1.RepositoryIndex) (*prometheusv1.StorageSpec, error) {
 	prometheusStorageSpec := cr.Spec.Storage.PrometheusStorageSpec
 	if cr.ExternalSyncDisabled() {

--- a/controllers/reconcilers/configuration/token_refresher.go
+++ b/controllers/reconcilers/configuration/token_refresher.go
@@ -160,6 +160,9 @@ func (r *Reconciler) createDeploymentFor(ctx context.Context, cr *v1.Observabili
 						"app.kubernetes.io/name":      config.Name,
 						"app.kubernetes.io/version":   TokenRefresherImageTag,
 					},
+					Annotations: map[string]string{
+						"cluster-autoscaler.kubernetes.io/safe-to-evict": "true",
+					},
 				},
 				Spec: v12.PodSpec{
 					PriorityClassName: model.ObservabilityPriorityClassName,

--- a/controllers/reconcilers/configuration/token_refresher.go
+++ b/controllers/reconcilers/configuration/token_refresher.go
@@ -160,9 +160,6 @@ func (r *Reconciler) createDeploymentFor(ctx context.Context, cr *v1.Observabili
 						"app.kubernetes.io/name":      config.Name,
 						"app.kubernetes.io/version":   TokenRefresherImageTag,
 					},
-					Annotations: map[string]string{
-						"cluster-autoscaler.kubernetes.io/safe-to-evict": "true",
-					},
 				},
 				Spec: v12.PodSpec{
 					PriorityClassName: model.ObservabilityPriorityClassName,


### PR DESCRIPTION
Jira: [MGDSTRM-9608](https://issues.redhat.com/browse/MGDSTRM-9608)
Adds `"cluster-autoscaler.kubernetes.io/safe-to-evict": "true"` annotation to relevant pods (alertmanager, prometheus and grafana) created by Operator