### PR TITLE
feat: switch to community Prometheus Operator index and update version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,6 @@ test/unit: generate fmt vet manifests
 	-e "github.com/redhat-developer/observability-operator/v3/controllers/reconcilers/csv/" \
 	-e "github.com/redhat-developer/observability-operator/v3/controllers/reconcilers/grafana_configuration/" \
 	-e "github.com/redhat-developer/observability-operator/v3/controllers/reconcilers/grafana_installation/" \
-	-e "github.com/redhat-developer/observability-operator/v3/controllers/reconcilers/prometheus_installation/" \
 	-e "github.com/redhat-developer/observability-operator/v3/controllers/reconcilers/prometheus_configuration/" \
 	-e "github.com/redhat-developer/observability-operator/v3/controllers/reconcilers/promtail_installation/" \
 	-e "github.com/redhat-developer/observability-operator/v3/controllers/token/token_fetcher.go" \

--- a/controllers/reconcilers/configuration/token_refresher.go
+++ b/controllers/reconcilers/configuration/token_refresher.go
@@ -100,7 +100,7 @@ func (r *Reconciler) createNetworkPolicyFor(ctx context.Context, cr *v1.Observab
 	case model.LogsTokenRefresher:
 		selector["app"] = "promtail"
 	case model.MetricsTokenRefresher:
-		selector["app"] = "prometheus"
+		selector["app.kubernetes.io/name"] = "prometheus"
 	}
 
 	_, err := controllerutil.CreateOrUpdate(ctx, r.client, policy, func() error {

--- a/controllers/reconcilers/prometheus_installation/prometheus_installation_reconciler.go
+++ b/controllers/reconcilers/prometheus_installation/prometheus_installation_reconciler.go
@@ -10,7 +10,7 @@ import (
 	"github.com/redhat-developer/observability-operator/v3/controllers/model"
 	"github.com/redhat-developer/observability-operator/v3/controllers/reconcilers"
 	"github.com/redhat-developer/observability-operator/v3/controllers/utils"
-	v12 "k8s.io/api/apps/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -55,7 +55,7 @@ func (r *Reconciler) Cleanup(ctx context.Context, cr *v1.Observability) (v1.Obse
 	}
 
 	// We have to remove the prometheus operator deployment manually
-	deployments := &v12.DeploymentList{}
+	deployments := &appsv1.DeploymentList{}
 	opts := &client.ListOptions{
 		Namespace: cr.Namespace,
 	}
@@ -120,7 +120,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, cr *v1.Observability, s *v1.
 
 func (r *Reconciler) waitForPrometheusOperator(ctx context.Context, cr *v1.Observability) (v1.ObservabilityStageStatus, error) {
 	// We have to remove the prometheus operator deployment manually
-	deployments := &v12.DeploymentList{}
+	deployments := &appsv1.DeploymentList{}
 	opts := &client.ListOptions{
 		Namespace: cr.GetPrometheusOperatorNamespace(),
 	}
@@ -253,7 +253,7 @@ func (r *Reconciler) removePrometheusOperatorIndexResources(ctx context.Context,
 	}
 
 	// We have to remove the prometheus operator deployment manually
-	deployments := &v12.DeploymentList{}
+	deployments := &appsv1.DeploymentList{}
 	opts := &client.ListOptions{
 		Namespace: cr.Namespace,
 	}

--- a/controllers/reconcilers/prometheus_installation/prometheus_installation_reconciler_test.go
+++ b/controllers/reconcilers/prometheus_installation/prometheus_installation_reconciler_test.go
@@ -1,0 +1,196 @@
+package prometheus_installation
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	v1 "github.com/redhat-developer/observability-operator/v3/api/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestPrometheusInstallationReconciler_RemovePrometheusOperatorIndexResources(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = v1.SchemeBuilder.AddToScheme(scheme)
+	_ = v1alpha1.SchemeBuilder.AddToScheme(scheme)
+	_ = appsv1.SchemeBuilder.AddToScheme(scheme)
+
+	type fields struct {
+		client client.Client
+		scheme *runtime.Scheme
+	}
+
+	type args struct {
+		ctx    context.Context
+		cr     *v1.Observability
+		source *v1alpha1.CatalogSource
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		fields  fields
+		wantErr bool
+	}{
+		{
+			name: "Success when resources found and deleted",
+			args: args{
+				ctx: context.TODO(),
+				cr: &v1.Observability{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "test-namespace",
+					},
+				},
+				source: &v1alpha1.CatalogSource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "prometheus-catalogsource",
+						Namespace: "test-namespace",
+					},
+				},
+			},
+			fields: fields{
+				client: fakeclient.NewFakeClientWithScheme(scheme,
+					&v1alpha1.Subscription{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "prometheus-subscription",
+							Namespace: "test-namespace",
+						},
+					},
+					&appsv1.DeploymentList{
+						Items: []appsv1.Deployment{
+							{
+								ObjectMeta: metav1.ObjectMeta{
+									Name:      "prometheus-operator",
+									Namespace: "test-namespace",
+								},
+							},
+						},
+					},
+					&v1alpha1.ClusterServiceVersion{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "prometheusoperator.0.45.0",
+							Namespace: "test-namespace",
+						},
+					},
+				),
+			},
+			wantErr: false,
+		},
+		{
+			name: "Success when resources not found",
+			args: args{
+				ctx: context.TODO(),
+				cr: &v1.Observability{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "test-namespace",
+					},
+				},
+				source: &v1alpha1.CatalogSource{},
+			},
+			fields: fields{
+				client: fakeclient.NewFakeClientWithScheme(scheme),
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		test := tt
+		t.Run(test.name, func(t *testing.T) {
+			g := NewWithT(t)
+			r := &Reconciler{
+				client: test.fields.client,
+				scheme: test.fields.scheme,
+			}
+			err := r.removePrometheusOperatorIndexResources(test.args.ctx, test.args.source, test.args.cr)
+			g.Expect(err != nil).To(Equal(test.wantErr))
+		})
+	}
+}
+
+func TestPrometheusInstallationReconciler_ReconcileCatalogSource(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = v1alpha1.SchemeBuilder.AddToScheme(scheme)
+	_ = appsv1.SchemeBuilder.AddToScheme(scheme)
+
+	type fields struct {
+		client client.Client
+		scheme *runtime.Scheme
+	}
+
+	type args struct {
+		ctx context.Context
+		cr  *v1.Observability
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		fields  fields
+		wantErr bool
+		want    v1.ObservabilityStageStatus
+	}{
+		{
+			name: "Success when catalogsource found with old custom index image and removed",
+			args: args{
+				ctx: context.TODO(),
+				cr: &v1.Observability{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "test-namespace",
+					},
+				},
+			},
+			fields: fields{
+				client: fakeclient.NewFakeClientWithScheme(scheme,
+					&v1alpha1.CatalogSource{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "prometheus-catalogsource",
+							Namespace: "test-namespace",
+						},
+						Spec: v1alpha1.CatalogSourceSpec{
+							Image: "quay.io/integreatly/custom-prometheus-index:1.0.0",
+						},
+					},
+				),
+			},
+			wantErr: false,
+			want:    v1.ResultSuccess,
+		},
+		{
+			name: "Success when catalogsource with old custom index image not found",
+			args: args{
+				ctx: context.TODO(),
+				cr: &v1.Observability{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "test-namespace",
+					},
+				},
+			},
+			fields: fields{
+				client: fakeclient.NewFakeClientWithScheme(scheme),
+			},
+			wantErr: false,
+			want:    v1.ResultSuccess,
+		},
+	}
+
+	for _, tt := range tests {
+		test := tt
+		t.Run(test.name, func(t *testing.T) {
+			g := NewWithT(t)
+			r := &Reconciler{
+				client: test.fields.client,
+				scheme: test.fields.scheme,
+			}
+
+			status, err := r.reconcileCatalogSource(test.args.ctx, test.args.cr)
+			g.Expect(err != nil).To(Equal(test.wantErr))
+			g.Expect(status).To(Equal(test.want))
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	k8s.io/api v0.20.6
 	k8s.io/apimachinery v0.20.6
 	k8s.io/client-go v12.0.0+incompatible
-	sigs.k8s.io/controller-runtime v0.6.2
+	sigs.k8s.io/controller-runtime v0.12.1
 )
 
 require (
@@ -41,22 +41,17 @@ require (
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.15 // indirect
 )
 
-replace k8s.io/client-go => k8s.io/client-go v0.19.2
-
-replace k8s.io/api => k8s.io/api v0.19.2
-
-replace k8s.io/apimachinery => k8s.io/apimachinery v0.19.2
-
-replace k8s.io/apiserver => k8s.io/apiserver v0.19.2
-
-replace github.com/opencontainers/runc => github.com/opencontainers/runc v1.1.2
-
-replace github.com/containerd/containerd => github.com/containerd/containerd v1.5.13
-
-replace github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
-
-replace github.com/docker/distribution => github.com/docker/distribution v2.8.0+incompatible
-
-replace go.mongodb.org/mongo-driver => go.mongodb.org/mongo-driver v1.5.1
-
-replace github.com/opencontainers/image-spec => github.com/opencontainers/image-spec v1.0.2
+replace (
+	github.com/containerd/containerd => github.com/containerd/containerd v1.5.13
+	github.com/docker/distribution => github.com/docker/distribution v2.8.0+incompatible
+	github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
+	github.com/opencontainers/image-spec => github.com/opencontainers/image-spec v1.0.2
+	github.com/opencontainers/runc => github.com/opencontainers/runc v1.1.2
+	go.mongodb.org/mongo-driver => go.mongodb.org/mongo-driver v1.5.1
+	k8s.io/api => k8s.io/api v0.19.2
+	k8s.io/apimachinery => k8s.io/apimachinery v0.19.2
+	k8s.io/apiserver => k8s.io/apiserver v0.19.2
+	k8s.io/client-go => k8s.io/client-go v0.19.2
+	sigs.k8s.io/controller-runtime => sigs.k8s.io/controller-runtime v0.6.3
+	sigs.k8s.io/controller-runtime/pkg/client/fake => sigs.k8s.io/controller-runtime/pkg/client/fake v0.12.1
+)

--- a/go.sum
+++ b/go.sum
@@ -2059,6 +2059,8 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.15/go.mod h1:LEScyz
 sigs.k8s.io/controller-runtime v0.6.0/go.mod h1:CpYf5pdNY/B352A1TFLAS2JVSlnGQ5O2cftPHndTroo=
 sigs.k8s.io/controller-runtime v0.6.2 h1:jkAnfdTYBpFwlmBn3pS5HFO06SfxvnTZ1p5PeEF/zAA=
 sigs.k8s.io/controller-runtime v0.6.2/go.mod h1:vhcq/rlnENJ09SIRp3EveTaZ0yqH526hjf9iJdbUJ/E=
+sigs.k8s.io/controller-runtime v0.6.3 h1:SBbr+inLPEKhvlJtrvDcwIpm+uhDvp63Bl72xYJtoOE=
+sigs.k8s.io/controller-runtime v0.6.3/go.mod h1:WlZNXcM0++oyaQt4B7C2lEE5JYRs8vJUzRP4N4JpdAY=
 sigs.k8s.io/controller-tools v0.2.4/go.mod h1:m/ztfQNocGYBgTTCmFdnK94uVvgxeZeE3LtJvd/jIzA=
 sigs.k8s.io/controller-tools v0.3.0/go.mod h1:enhtKGfxZD1GFEoMgP8Fdbu+uKQ/cq1/WGJhdVChfvI=
 sigs.k8s.io/kubebuilder v1.0.9-0.20200513134826-f07a0146a40b/go.mod h1:FGPx0hvP73+bapzWoy5ePuhAJYgJjrFbPxgvWyortM0=


### PR DESCRIPTION
Jira: [MGDSTRM-9688](https://issues.redhat.com/browse/MGDSTRM-9688), [MGDSTRM-9512](https://issues.redhat.com/browse/MGDSTRM-9512)

This change directs the Operator to install Prometheus Operator from maintained community index instead of previous custom index.
The version of the Prometheus Operator installed is also upgraded from `v0.45.0` to `v0.56.3`.
Also adds initial implementation of unit testing using fake k8s client.

### Verification
Fresh install:
* Run this PR locally (CRC/remote cluster)
* Check that version of Prometheus Operator installed is `v0.56.3`
* Ensure there are no errors logged by Observability Operator
* Ensure alertmanager and prometheus routes are created and functional.

Upgrade from v3.0.15:
* Install v3.0.15 of the Operator using the RHOAS image (`quay.io/rhoas/observability-operator-index:v3.0.15`)
* Allow the Operator to install fully and without errors. Check that Operator has installed v0.45.0 of the Prometheus Operator
* The Operator can be updated to include this change using the following index (`quay.io/vmanley/observability-operator-index:v3.0.17`)
* Ensure the Operator upgrades without error. Check that the Prometheus Operator has also been upgraded (from 0.45.0 to 0.56.3)
* Ensure alertmanager and prometheus routes remain functional.
