### PR TITLE
add toleration for node taint to unblock fluentd pods

### DIFF
--- a/controllers/model/logging_resources.go
+++ b/controllers/model/logging_resources.go
@@ -26,6 +26,12 @@ func GetClusterLoggingCR() *v14.ClusterLogging {
 		Requests: map[v13.ResourceName]resource.Quantity{v13.ResourceMemory: resource.MustParse("736Mi")},
 	}
 
+	profileToleration := v13.Toleration{
+		Key:      "bf2.org/kafkaInstanceProfileType",
+		Operator: "Exists",
+		Effect:   "NoExecute",
+	}
+
 	return &v14.ClusterLogging{
 		TypeMeta: v12.TypeMeta{},
 		ObjectMeta: v12.ObjectMeta{
@@ -39,7 +45,8 @@ func GetClusterLoggingCR() *v14.ClusterLogging {
 				Logs: &v14.LogCollectionSpec{
 					Type: "fluentd",
 					CollectorSpec: v14.CollectorSpec{
-						Resources: memoryRequests,
+						Resources:   memoryRequests,
+						Tolerations: []v13.Toleration{profileToleration},
 					},
 				},
 			},


### PR DESCRIPTION
Add a toleration to the fluentd collector pods to tolerate a taint added to the nodes.

_The toleration added to the clusterLogging CR_

![Screenshot from 2022-12-06 12-20-08](https://user-images.githubusercontent.com/16290921/205911122-2eda5384-788f-4580-a396-edf858f31195.png)

_The toleration rendered down to the collector daemonset_

![Screenshot from 2022-12-06 12-20-35](https://user-images.githubusercontent.com/16290921/205911218-b466db06-7bae-4e7f-828f-21534be79766.png)
