### PR TITLE
fix: correct token refresher network policy selector

### DIFF
--- a/controllers/reconcilers/configuration/token_refresher.go
+++ b/controllers/reconcilers/configuration/token_refresher.go
@@ -100,7 +100,7 @@ func (r *Reconciler) createNetworkPolicyFor(ctx context.Context, cr *v1.Observab
 	case model.LogsTokenRefresher:
 		selector["app"] = "promtail"
 	case model.MetricsTokenRefresher:
-		selector["app.kubernetes.io/name"] = "prometheus"
+		selector["app"] = "prometheus"
 	}
 
 	_, err := controllerutil.CreateOrUpdate(ctx, r.client, policy, func() error {


### PR DESCRIPTION
This change corrects the token refresher network policy selector for v0.45.0 of Prometheus Operator