### PR TITLE
feat: configurable CR watch namespace and secret label match expressions

### DIFF
--- a/controllers/reconcilers/configuration/configuration_reconciler_test.go
+++ b/controllers/reconcilers/configuration/configuration_reconciler_test.go
@@ -9,6 +9,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -216,6 +217,142 @@ func TestConfigurationReconciler_WaitForResourcesDeployment(t *testing.T) {
 			status, err := r.waitForResourcesDeployment(test.args.ctx, test.args.cr)
 			g.Expect(err != nil).To(Equal(test.wantErr))
 			g.Expect(status).To(Equal(test.want))
+		})
+	}
+}
+
+func parseSelector(value string) labels.Selector {
+	selector, err := labels.Parse(value)
+	Expect(err == nil).To(Equal(true))
+	return selector
+}
+
+func TestConfigurationReconciler_buildConfigurationSelector(t *testing.T) {
+	RegisterTestingT(t)
+
+	type args struct {
+		observabilityStack *v1.Observability
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		want    labels.Selector
+		wantErr bool
+	}{
+		{
+			name: "default matchLabels",
+			args: args{
+				observabilityStack: &v1.Observability{
+					Spec: v1.ObservabilitySpec{
+						ConfigurationSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"configures": "observability-operator",
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+			want:    parseSelector("configures=observability-operator"),
+		},
+		{
+			name: "default match label with multiple match expressions",
+			args: args{
+				observabilityStack: &v1.Observability{
+					Spec: v1.ObservabilitySpec{
+						ConfigurationSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"configures": "observability-operator",
+							},
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      "app",
+									Operator: metav1.LabelSelectorOpIn,
+									Values: []string{
+										"kas", "rhosak",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+			want:    parseSelector("configures=observability-operator, app in (kas,rhosak)"),
+		},
+		{
+			name: "empty selector",
+			args: args{
+				observabilityStack: &v1.Observability{
+					Spec: v1.ObservabilitySpec{},
+				},
+			},
+			wantErr: false,
+			want:    labels.NewSelector(),
+		},
+		{
+			name: "multiple labels with multiple match expressions",
+			args: args{
+				observabilityStack: &v1.Observability{
+					Spec: v1.ObservabilitySpec{
+						ConfigurationSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"configures": "observability-operator",
+								"managed-by": "kas-fleetshard",
+							},
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      "app",
+									Operator: metav1.LabelSelectorOpIn,
+									Values: []string{
+										"kas", "rhosak",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+			want: parseSelector(`
+				configures=observability-operator,
+				managed-by=kas-fleetshard,
+				app in (kas,rhosak)
+			`),
+		},
+		{
+			name: "bad match expression operator",
+			args: args{
+				observabilityStack: &v1.Observability{
+					Spec: v1.ObservabilitySpec{
+						ConfigurationSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"configures": "observability-operator",
+							},
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      "app",
+									Operator: "invalid",
+									Values: []string{
+										"kas", "rhosak",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+			want:    labels.Nothing(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := buildConfigurationSelector(tt.args.observabilityStack)
+			Expect(err != nil).To(Equal(tt.wantErr))
+			Expect(result).To(Equal(tt.want))
 		})
 	}
 }


### PR DESCRIPTION
**Jira Issues:** 
- [MGDSTRM-10394](https://issues.redhat.com/browse/MGDSTRM-10394) Observability Operator: Add CR selection criteria to reconcile and validating webhook
- [MGDSTRM-10448](https://issues.redhat.com/browse/MGDSTRM-10448) Observability Operator: support configuration secret match expressions

Initial work to allow multiple Observability operators to run in the same cluster without competing over Observability CRs and configuration secrets. This does not yet include changes to the validating webhook which may be necessary also.

Signed-off-by: Michael Edgar <medgar@redhat.com>