### PR TITLE
Add cluster scope check for Grafana migration

### DIFF
--- a/controllers/reconcilers/migration/resource_name_migration.go
+++ b/controllers/reconcilers/migration/resource_name_migration.go
@@ -143,16 +143,18 @@ func (r *Reconciler) Reconcile(ctx context.Context, cr *v1.Observability, s *v1.
 	}
 
 	//check if Grafana CR need migration
-	if cr.Spec.GrafanaDefaultName == "" {
-		//remove Grafana resources
-		grafanaCR := model.GetGrafanaCr(cr)
-		grafanaCR.Name = model.GrafanaOldDefaultName
-		err := r.client.Delete(ctx, grafanaCR)
-		if err != nil && !errors.IsNotFound(err) {
-			return v1.ResultFailed, err
-		}
+	if !cr.DescopedModeEnabled() {
+		if cr.Spec.GrafanaDefaultName == "" {
+			//remove Grafana resources
+			grafanaCR := model.GetGrafanaCr(cr)
+			grafanaCR.Name = model.GrafanaOldDefaultName
+			err := r.client.Delete(ctx, grafanaCR)
+			if err != nil && !errors.IsNotFound(err) {
+				return v1.ResultFailed, err
+			}
 
-		utils.WaitForGrafanaToBeRemoved(ctx, cr, r.client)
+			utils.WaitForGrafanaToBeRemoved(ctx, cr, r.client)
+		}
 	}
 
 	//check if Promtail resources need migration


### PR DESCRIPTION
Fix to avoid situation where Operator tries to migrate an non-existing Grafana CR when the Operator is installed in cluster scope.

#### Verification
- Install the v3.0.14 of Operator in cluster scope by installing in `openshift-operators` namespace. This can be done with a CatalogSource applied to `openshift-marketplace` namespace with the index image `quay.io/rhoas/observability-operator-index:v3.0.14`
- The Operator can be blocked from initialising a Observability CR by applying a ConfigMap with the name `observability-operator-no-init` in the `openshift-operator` namespace
- Apply the following CR:
```
apiVersion: observability.redhat.com/v1
kind: Observability
metadata:
  name: observability-stack
  labels:
    managed-by: observability-operator
spec:
  configurationSelector:
    matchLabels:
      configures: observability-operator
  resyncPeriod: 1h
  retention: 45d
  descopedMode:
    enabled: true
    prometheusOperatorNamespace: observability-prometheus
  selfContained:
    disableBlackboxExporter: true
    disablePagerDuty: true
    disableSmtp: true
```
- The stack should fully install without error.
- Upgrade the Operator to v4.0.4 (modify the existing CatalogSource with the index image `quay.io/rhoas/observability-operator-index:v4.0.4`).
- When upgraded check the logs of the Operator pod in the `openshift-operators`. The following error will be logged:
```
ERROR controllers.Observability reconciler error in stage resource name migration {"observability": "openshift-operators/observability-stack", "error": "no matches for kind \"Grafana\" in version \"integreatly.org/v1alpha1\""}
 ```
- Upgrade the Operator to an index image including this change: `quay.io/vmanley/observability-operator-index:v4.0.9`
- Operator should upgrade without error in the Operator logs