### PR TITLE
feat: configurable grafana init image 

### DIFF
--- a/api/v1/observability_types.go
+++ b/api/v1/observability_types.go
@@ -90,6 +90,7 @@ type SelfContained struct {
 	GrafanaResourceRequirement            *v1.ResourceRequirements `json:"grafanaResourceRequirement,omitempty"`
 	GrafanaOperatorResourceRequirement    *v1.ResourceRequirements `json:"grafanaOperatorResourceRequirement,omitempty"`
 	GrafanaVersion                        string                   `json:"grafanaVersion,omitempty"`
+	GrafanaInitImage                      string                   `json:"grafanaInitImage,omitempty"`
 	DisableLogging                        *bool                    `json:"disableLogging,omitempty"`
 }
 

--- a/config/crd/bases/observability.redhat.com_observabilities.yaml
+++ b/config/crd/bases/observability.redhat.com_observabilities.yaml
@@ -1033,6 +1033,8 @@ spec:
                         type: object
                     type: object
                     x-kubernetes-map-type: atomic
+                  grafanaInitImage:
+                    type: string
                   grafanaOperatorResourceRequirement:
                     description: ResourceRequirements describes the compute resource
                       requirements.

--- a/controllers/model/grafana_resources.go
+++ b/controllers/model/grafana_resources.go
@@ -12,7 +12,10 @@ import (
 
 var defaultGrafanaLabelSelectors = map[string]string{"app": "strimzi"}
 
-const GrafanaOldDefaultName = "kafka-grafana"
+const (
+	GrafanaOldDefaultName   = "kafka-grafana"
+	GrafanaDefaultInitImage = "quay.io/grafana-operator/grafana_plugins_init:0.1.0"
+)
 
 func GetDefaultNameGrafana(cr *v1.Observability) string {
 	if cr.Spec.SelfContained != nil && cr.Spec.GrafanaDefaultName != "" {
@@ -138,4 +141,11 @@ func GetGrafanaOperatorResourceRequirement(cr *v1.Observability) *v14.ResourceRe
 		return cr.Spec.SelfContained.GrafanaOperatorResourceRequirement
 	}
 	return &v14.ResourceRequirements{}
+}
+
+func GetGrafanaInitImage(cr *v1.Observability) string {
+	if cr.Spec.SelfContained != nil && cr.Spec.SelfContained.GrafanaInitImage != "" {
+		return cr.Spec.SelfContained.GrafanaInitImage
+	}
+	return GrafanaDefaultInitImage
 }

--- a/controllers/model/grafana_resources_test.go
+++ b/controllers/model/grafana_resources_test.go
@@ -532,3 +532,51 @@ func TestGrafanaResources_GetGrafanaOperatorResourceRequirement(t *testing.T) {
 		})
 	}
 }
+
+func TestGetGrafanaInitImage(t *testing.T) {
+	type args struct {
+		cr *v1.Observability
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "test default image is returned when spec selfContained is nil",
+			args: args{
+				cr: buildObservabilityCR(nil),
+			},
+			want: GrafanaDefaultInitImage,
+		},
+		{
+			name: "test default image is returned when spec grafanaInitImage is empty",
+			args: args{
+				cr: buildObservabilityCR(func(obsCR *v1.Observability) {
+					obsCR.Spec.SelfContained = &v1.SelfContained{
+						GrafanaInitImage: "",
+					}
+				}),
+			},
+			want: GrafanaDefaultInitImage,
+		},
+		{
+			name: "test image in spec is returned when specified in spec",
+			args: args{
+				cr: buildObservabilityCR(func(obsCR *v1.Observability) {
+					obsCR.Spec.SelfContained = &v1.SelfContained{
+						GrafanaInitImage: "quay.io/example/test:0.0.1",
+					}
+				}),
+			},
+			want: "quay.io/example/test:0.0.1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetGrafanaInitImage(tt.args.cr); got != tt.want {
+				t.Errorf("GetGrafanaInitImage() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/controllers/reconcilers/configuration/grafana.go
+++ b/controllers/reconcilers/configuration/grafana.go
@@ -100,6 +100,7 @@ func (r *Reconciler) reconcileGrafanaCr(ctx context.Context, cr *v1.Observabilit
 				TargetPort:  "grafana-proxy",
 				Termination: "reencrypt",
 			},
+			InitImage: model.GetGrafanaInitImage(cr),
 			Secrets: []string{
 				"grafana-k8s-tls",
 				"grafana-k8s-proxy",


### PR DESCRIPTION
* Allow grafana init container to be configurable through the observability CR

![image](https://user-images.githubusercontent.com/24636860/216306024-0df06e7e-6043-4718-a814-ca0f69723699.png)

* Override grafana init container to use more recent `quay.io/grafana-operator/grafana_plugins_init:0.1.0` due to better image grading by default if not specified in the CR

![image](https://user-images.githubusercontent.com/24636860/216303537-01f599eb-b95b-4a24-888e-98713860d0bd.png)


