### PR TITLE
Update oauth proxy image version

### DIFF
--- a/controllers/reconcilers/configuration/alertmanager.go
+++ b/controllers/reconcilers/configuration/alertmanager.go
@@ -17,6 +17,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
+const DefaultOriginOauthProxyImage = "quay.io/openshift/origin-oauth-proxy:4.9"
+
 func (r *Reconciler) reconcileAlertmanager(ctx context.Context, cr *v1.Observability, indexes []v1.RepositoryIndex) error {
 	alertmanager := model.GetAlertmanagerCr(cr)
 	configSecretName := model.GetAlertmanagerSecretName(cr)
@@ -58,7 +60,7 @@ func (r *Reconciler) reconcileAlertmanager(ctx context.Context, cr *v1.Observabi
 			Containers: []v12.Container{
 				{
 					Name:  "oauth-proxy",
-					Image: "quay.io/openshift/origin-oauth-proxy:4.8",
+					Image: DefaultOriginOauthProxyImage,
 					Args: []string{
 						"-provider=openshift",
 						"-https-address=:9091",

--- a/controllers/reconcilers/configuration/grafana.go
+++ b/controllers/reconcilers/configuration/grafana.go
@@ -51,7 +51,7 @@ func (r *Reconciler) reconcileGrafanaCr(ctx context.Context, cr *v1.Observabilit
 			Containers: []core.Container{
 				{
 					Name:  "grafana-proxy",
-					Image: "quay.io/openshift/origin-oauth-proxy:4.8",
+					Image: DefaultOriginOauthProxyImage,
 					Args: []string{
 						"-provider=openshift",
 						"-pass-basic-auth=false",

--- a/controllers/reconcilers/configuration/prometheus.go
+++ b/controllers/reconcilers/configuration/prometheus.go
@@ -264,7 +264,7 @@ func (r *Reconciler) reconcilePrometheus(ctx context.Context, cr *v1.Observabili
 
 	sidecars = append(sidecars, kv1.Container{
 		Name:  "oauth-proxy",
-		Image: "quay.io/openshift/origin-oauth-proxy:4.8",
+		Image: DefaultOriginOauthProxyImage,
 		Args: []string{
 			"-provider=openshift",
 			"-https-address=:9091",


### PR DESCRIPTION
This change updates the `origin-oauth-proxy` image from `v4.8` to `v4.9`.

This version was chosen as it appears to have fewer security vulnerabilities than subsequent available versions