### PR TITLE
Bump default Grafana Operator version

### DIFF
--- a/controllers/reconcilers/grafana_installation/grafana_installation_reconciler.go
+++ b/controllers/reconcilers/grafana_installation/grafana_installation_reconciler.go
@@ -17,7 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-const GrafanaOperatorDefaultVersion = "v3.10.7"
+const GrafanaOperatorDefaultVersion = "v3.10.8"
 
 type Reconciler struct {
 	client client.Client


### PR DESCRIPTION
Bump default Grafana Operator version from `v3.10.7` to `v3.10.8`