### PR TITLE
fix: apply updates to cluster log forwarder cr

### DIFF
--- a/controllers/model/logging_resources.go
+++ b/controllers/model/logging_resources.go
@@ -55,53 +55,11 @@ func GetClusterLoggingCR() *v14.ClusterLogging {
 
 }
 
-func GetClusterLogForwarderPipeline() *v14.PipelineSpec {
-	return &v14.PipelineSpec{
-		OutputRefs: []string{"cloudwatch"},
-		InputRefs:  []string{"kafka-operator-application-logs"},
-		Name:       "observability-app-logs",
-	}
-}
-
 func GetClusterLogForwarderCR() *v14.ClusterLogForwarder {
-
-	kafkaOperatorsInput := v14.InputSpec{
-		Name: "kafka-operator-application-logs",
-		Application: &v14.Application{Namespaces: []string{"redhat-kas-fleetshard-operator", "redhat-managed-kafka-operator",
-			"redhat-kas-fleetshard-operator-qe", "redhat-managed-kafka-operator-qe"}},
-		Infrastructure: nil,
-		Audit:          nil,
-	}
-
-	kafkaOutput := v14.OutputSpec{
-		Name: "cloudwatch",
-		Type: "cloudwatch",
-		OutputTypeSpec: v14.OutputTypeSpec{
-			Cloudwatch: &v14.Cloudwatch{
-				Region:  "eu-west-1",
-				GroupBy: "namespaceName",
-			},
-		},
-		TLS: &v14.OutputTLSSpec{},
-		Secret: &v14.OutputSecretSpec{
-			Name: "clo-cloudwatchlogs-creds",
-		},
-	}
-
-	kafkaForwarder := v14.ClusterLogForwarder{
+	return &v14.ClusterLogForwarder{
 		ObjectMeta: v12.ObjectMeta{
 			Name:      "instance",
 			Namespace: "openshift-logging",
-			Labels: map[string]string{
-				"app.kubernetes.io/managed-by": "observability-operator",
-			},
-		},
-		Spec: v14.ClusterLogForwarderSpec{
-			Inputs:         []v14.InputSpec{kafkaOperatorsInput},
-			Outputs:        []v14.OutputSpec{kafkaOutput},
-			OutputDefaults: &v14.OutputDefaults{},
 		},
 	}
-
-	return &kafkaForwarder
 }


### PR DESCRIPTION
Make sure that updates to the cluster log forwarder CR are applied, by assigning all the spec fields inside the `CreateOrUpdate` function.

This changes assumes that the CR is completely managed by the OO and it doesn't need to preserve any pre-existing state (which wasn't the case earlier). For this reason, I also removed all the appends (to e.g. the pipelines spec), because we know exactly what pipelines we want to configure and we can simply overwrite whatever is there. We never want to append.