### PR TITLE
Prepare release v4.1.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Current Operator version
-VERSION ?= 4.1.1
+VERSION ?= 4.1.2
 # Previous Operator version
-PREV_VERSION ?= 4.1.0
+PREV_VERSION ?= 4.1.1
 # Options for 'bundle-build'
 ifneq ($(origin CHANNELS), undefined)
 BUNDLE_CHANNELS := --channels=$(CHANNELS)

--- a/bundle/manifests/observability-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/observability-operator.clusterserviceversion.yaml
@@ -60,7 +60,7 @@ metadata:
     capabilities: Basic Install
     operators.operatorframework.io/builder: operator-sdk-v1.4.2
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
-  name: observability-operator.v4.1.1
+  name: observability-operator.v4.1.2
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -323,7 +323,7 @@ spec:
                 - --enable-leader-election
                 command:
                 - /manager
-                image: quay.io/rhoas/observability-operator:v4.1.1
+                image: quay.io/rhoas/observability-operator:v4.1.2
                 imagePullPolicy: IfNotPresent
                 livenessProbe:
                   httpGet:
@@ -413,8 +413,8 @@ spec:
   maturity: alpha
   provider:
     name: Red Hat
-  replaces: observability-operator.v4.1.0
-  version: 4.1.1
+  replaces: observability-operator.v4.1.1
+  version: 4.1.2
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/rhoas/observability-operator
-  newTag: v4.1.1
+  newTag: v4.1.2

--- a/config/manifests/bases/observability-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/observability-operator.clusterserviceversion.yaml
@@ -48,5 +48,5 @@ spec:
   maturity: alpha
   provider:
     name: Red Hat
-  replaces: observability-operator.v4.1.0
-  version: 4.1.1
+  replaces: observability-operator.v4.1.1
+  version: 4.1.2


### PR DESCRIPTION
Prepares v4.1.2 which includes updated images for Prometheus Operator index and token refresher