### PR TITLE
feat: allow configuring origin oauth proxy image

### DIFF
--- a/api/v1/observability_types.go
+++ b/api/v1/observability_types.go
@@ -92,6 +92,7 @@ type SelfContained struct {
 	GrafanaVersion                        string                   `json:"grafanaVersion,omitempty"`
 	GrafanaInitImage                      string                   `json:"grafanaInitImage,omitempty"`
 	DisableLogging                        *bool                    `json:"disableLogging,omitempty"`
+	OriginOauthProxyImage                 string                   `json:"originOauthProxyImage,omitempty"`
 }
 
 // ObservabilitySpec defines the desired state of Observability

--- a/config/crd/bases/observability.redhat.com_observabilities.yaml
+++ b/config/crd/bases/observability.redhat.com_observabilities.yaml
@@ -1091,6 +1091,8 @@ spec:
                     type: object
                   grafanaVersion:
                     type: string
+                  originOauthProxyImage:
+                    type: string
                   overrideSelectors:
                     type: boolean
                   podMonitorLabelSelector:

--- a/controllers/reconcilers/configuration/alertmanager.go
+++ b/controllers/reconcilers/configuration/alertmanager.go
@@ -17,8 +17,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-const DefaultOriginOauthProxyImage = "quay.io/openshift/origin-oauth-proxy:4.9"
-
 func (r *Reconciler) reconcileAlertmanager(ctx context.Context, cr *v1.Observability, indexes []v1.RepositoryIndex) error {
 	alertmanager := model.GetAlertmanagerCr(cr)
 	configSecretName := model.GetAlertmanagerSecretName(cr)
@@ -60,7 +58,7 @@ func (r *Reconciler) reconcileAlertmanager(ctx context.Context, cr *v1.Observabi
 			Containers: []v12.Container{
 				{
 					Name:  "oauth-proxy",
-					Image: DefaultOriginOauthProxyImage,
+					Image: GetOriginOauthProxyImage(cr),
 					Args: []string{
 						"-provider=openshift",
 						"-https-address=:9091",

--- a/controllers/reconcilers/configuration/grafana.go
+++ b/controllers/reconcilers/configuration/grafana.go
@@ -51,7 +51,7 @@ func (r *Reconciler) reconcileGrafanaCr(ctx context.Context, cr *v1.Observabilit
 			Containers: []core.Container{
 				{
 					Name:  "grafana-proxy",
-					Image: DefaultOriginOauthProxyImage,
+					Image: GetOriginOauthProxyImage(cr),
 					Args: []string{
 						"-provider=openshift",
 						"-pass-basic-auth=false",

--- a/controllers/reconcilers/configuration/origin_proxy.go
+++ b/controllers/reconcilers/configuration/origin_proxy.go
@@ -1,0 +1,13 @@
+package configuration
+
+import v1 "github.com/redhat-developer/observability-operator/v4/api/v1"
+
+const DefaultOriginOauthProxyImage = "quay.io/openshift/origin-oauth-proxy:4.9"
+
+func GetOriginOauthProxyImage(cr *v1.Observability) string {
+	if cr.Spec.SelfContained != nil && cr.Spec.SelfContained.OriginOauthProxyImage != "" {
+		return cr.Spec.SelfContained.OriginOauthProxyImage
+	}
+
+	return DefaultOriginOauthProxyImage
+}

--- a/controllers/reconcilers/configuration/origin_proxy_test.go
+++ b/controllers/reconcilers/configuration/origin_proxy_test.go
@@ -1,0 +1,55 @@
+package configuration
+
+import (
+	"testing"
+
+	v1 "github.com/redhat-developer/observability-operator/v4/api/v1"
+)
+
+func TestGetOriginOauthProxyImage(t *testing.T) {
+	type args struct {
+		cr *v1.Observability
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "test default image is returned when self contained is nil in cr",
+			args: args{
+				cr: buildObservabilityCR(nil),
+			},
+			want: DefaultOriginOauthProxyImage,
+		},
+		{
+			name: "test default image is returned when empty in spec",
+			args: args{
+				cr: buildObservabilityCR(func(obsCR *v1.Observability) {
+					obsCR.Spec.SelfContained = &v1.SelfContained{
+						OriginOauthProxyImage: "",
+					}
+				}),
+			},
+			want: DefaultOriginOauthProxyImage,
+		},
+		{
+			name: "test image in spec is returned when not empty",
+			args: args{
+				cr: buildObservabilityCR(func(obsCR *v1.Observability) {
+					obsCR.Spec.SelfContained = &v1.SelfContained{
+						OriginOauthProxyImage: "customOriginOauthProxyImage",
+					}
+				}),
+			},
+			want: "customOriginOauthProxyImage",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetOriginOauthProxyImage(tt.args.cr); got != tt.want {
+				t.Errorf("GetOriginOauthProxyImage() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/controllers/reconcilers/configuration/prometheus.go
+++ b/controllers/reconcilers/configuration/prometheus.go
@@ -264,7 +264,7 @@ func (r *Reconciler) reconcilePrometheus(ctx context.Context, cr *v1.Observabili
 
 	sidecars = append(sidecars, kv1.Container{
 		Name:  "oauth-proxy",
-		Image: DefaultOriginOauthProxyImage,
+		Image: GetOriginOauthProxyImage(cr),
 		Args: []string{
 			"-provider=openshift",
 			"-https-address=:9091",


### PR DESCRIPTION
# Description
* Allow configuring oauth proxy image via Observability CR

# Verification
* Default image is used when not specificed in CR

![image](https://user-images.githubusercontent.com/24636860/221824231-d6a32169-4c7e-4c34-a175-6300b89e5ca3.png)

* Custom oauth proxy image is used when specified in CR

![image](https://user-images.githubusercontent.com/24636860/221826927-5c0cc34b-3342-47c5-99c1-5b10350c7695.png)
