### PR TITLE
fix: disable cleanup when CR is auto generated

### DIFF
--- a/controllers/observability_controller.go
+++ b/controllers/observability_controller.go
@@ -165,6 +165,16 @@ func (r *ObservabilityReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, err
 	}
 
+	// remove finalizers from existing CRs (unless the CR is manually created)
+	if len(obs.Finalizers) > 0 && r.noInit == false {
+		obs.Finalizers = []string{}
+		err = r.Update(ctx, obs)
+		return ctrl.Result{
+			Requeue:      true,
+			RequeueAfter: RequeueDelaySuccess,
+		}, err
+	}
+
 	return r.updateStatus(obs, nextStatus)
 }
 


### PR DESCRIPTION
removes all finalizers and disables cleanup if the CR was auto generated. Finalizers cause issues with namespace deletion and without the finalizer we will need to refactor to using owner references for all resources to do cleanup.