### PR TITLE
Update Prometheus Operator version

### DIFF
--- a/controllers/reconcilers/configuration/token_refresher.go
+++ b/controllers/reconcilers/configuration/token_refresher.go
@@ -100,7 +100,7 @@ func (r *Reconciler) createNetworkPolicyFor(ctx context.Context, cr *v1.Observab
 	case model.LogsTokenRefresher:
 		selector["app"] = "promtail"
 	case model.MetricsTokenRefresher:
-		selector["app"] = "prometheus"
+		selector["app.kubernetes.io/name"] = "prometheus"
 	}
 
 	_, err := controllerutil.CreateOrUpdate(ctx, r.client, policy, func() error {

--- a/controllers/reconcilers/prometheus_installation/prometheus_installation_reconciler.go
+++ b/controllers/reconcilers/prometheus_installation/prometheus_installation_reconciler.go
@@ -161,7 +161,7 @@ func (r *Reconciler) reconcileCatalogSource(ctx context.Context, cr *v1.Observab
 	_, err = controllerutil.CreateOrUpdate(ctx, r.client, source, func() error {
 		source.Spec = v1alpha1.CatalogSourceSpec{
 			SourceType: v1alpha1.SourceTypeGrpc,
-			Image:      "quay.io/integreatly/custom-prometheus-index:1.0.1",
+			Image:      "quay.io/integreatly/custom-prometheus-index:2.0.0",
 		}
 		return nil
 	})

--- a/controllers/reconcilers/prometheus_installation/prometheus_installation_reconciler_test.go
+++ b/controllers/reconcilers/prometheus_installation/prometheus_installation_reconciler_test.go
@@ -54,7 +54,7 @@ func TestPrometheusInstallationReconciler_ReconcileCatalogSource(t *testing.T) {
 							Namespace: "test-namespace",
 						},
 						Spec: v1alpha1.CatalogSourceSpec{
-							Image: "quay.io/integreatly/custom-prometheus-index:1.0.0",
+							Image: "quay.io/integreatly/custom-prometheus-index:2.0.0",
 						},
 					},
 				),


### PR DESCRIPTION
Bumping Prometheus Operator version to `v0.56.3`.

Note: This update of the Prometheus Operator requires a resync of the configuration resources. Therefore updating to this change can require a full `spec.resyncPeriod` as given in the Observability CR.