### PR TITLE
fix: remove requirement for tenant value in observatorium config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,7 +198,7 @@ index-push:
 
 # deploy required secrets to cluster
 NAMESPACE ?= "$(shell oc project | sed -e 's/Using project \"\([^"]*\)\".*/\1/g')"
-OBSERVATORIUM_TENANT ?= "managedKafka"
+OBSERVATORIUM_TENANT ?= ""
 OBSERVATORIUM_GATEWAY ?= "https://observatorium-mst.api.stage.openshift.com"
 OBSERVATORIUM_AUTH_TYPE ?= "redhat"
 OBSERVATORIUM_RHSSO_URL ?= "https://sso.redhat.com/auth/"

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ review the content of each!
 
     * The following parameters can be modified:
       * NAMESPACE: Defaults to current namespace in use.
-      * OBSERVATORIUM_TENANT:       Defaults to `managedKafka`
+      * OBSERVATORIUM_TENANT:       Defaults to ``
       * OBSERVATORIUM_GATEWAY:      Defaults to `https://observatorium-mst.api.stage.openshift.com`
       * OBSERVATORIUM_AUTH_TYPE:    Defaults to `redhat`
       * OBSERVATORIUM_RHSSO_URL:    Defaults to `https://sso.redhat.com/auth/`

--- a/api/v1/index.go
+++ b/api/v1/index.go
@@ -64,7 +64,7 @@ type ObservatoriumIndex struct {
 }
 
 func (in *ObservatoriumIndex) IsValid() bool {
-	return in.Gateway != "" && in.Tenant != ""
+	return in.Gateway != ""
 }
 
 type RemoteWriteIndex struct {

--- a/api/v1/index_test.go
+++ b/api/v1/index_test.go
@@ -52,9 +52,11 @@ func TestIndex_HasAuthServer(t *testing.T) {
 		},
 	}
 
-	RegisterTestingT(t)
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		test := tt
+		t.Run(test.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			config := &RedhatSsoConfig{
 				tt.fields.Url,
 				tt.fields.Realm,
@@ -63,8 +65,9 @@ func TestIndex_HasAuthServer(t *testing.T) {
 				tt.fields.LogsClient,
 				tt.fields.LogsSecret,
 			}
+
 			result := config.HasAuthServer()
-			Expect(result).To(Equal(tt.want))
+			g.Expect(result).To(Equal(tt.want))
 		})
 	}
 }
@@ -116,9 +119,11 @@ func TestIndex_HasMetrics(t *testing.T) {
 		},
 	}
 
-	RegisterTestingT(t)
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		test := tt
+		t.Run(test.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			config := &RedhatSsoConfig{
 				tt.fields.Url,
 				tt.fields.Realm,
@@ -127,8 +132,9 @@ func TestIndex_HasMetrics(t *testing.T) {
 				tt.fields.LogsClient,
 				tt.fields.LogsSecret,
 			}
+
 			result := config.HasMetrics()
-			Expect(result).To(Equal(tt.want))
+			g.Expect(result).To(Equal(tt.want))
 		})
 	}
 }
@@ -180,9 +186,11 @@ func TestIndex_HasLogs(t *testing.T) {
 		},
 	}
 
-	RegisterTestingT(t)
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		test := tt
+		t.Run(test.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			config := &RedhatSsoConfig{
 				tt.fields.Url,
 				tt.fields.Realm,
@@ -191,8 +199,9 @@ func TestIndex_HasLogs(t *testing.T) {
 				tt.fields.LogsClient,
 				tt.fields.LogsSecret,
 			}
+
 			result := config.HasLogs()
-			Expect(result).To(Equal(tt.want))
+			g.Expect(result).To(Equal(tt.want))
 		})
 	}
 }
@@ -235,13 +244,15 @@ func TestIndex_IsValid(t *testing.T) {
 				Gateway: "gateway",
 				Tenant:  "",
 			},
-			want: false,
+			want: true,
 		},
 	}
 
-	RegisterTestingT(t)
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		test := tt
+		t.Run(test.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			obsIndex := &ObservatoriumIndex{
 				tt.fields.Id,
 				tt.fields.SecretName,
@@ -251,8 +262,9 @@ func TestIndex_IsValid(t *testing.T) {
 				tt.fields.DexConfig,
 				tt.fields.RedhatSsoConfig,
 			}
+
 			result := obsIndex.IsValid()
-			Expect(result).To(Equal(tt.want))
+			g.Expect(result).To(Equal(tt.want))
 		})
 	}
 }

--- a/config/samples/secrets/observatorium-configuration-red-hat-sso.yaml
+++ b/config/samples/secrets/observatorium-configuration-red-hat-sso.yaml
@@ -4,7 +4,7 @@ metadata:
   name: observatorium-configuration-red-hat-sso
   namespace: kafka-observability
 stringData:
-  tenant: managedkafka
+  tenant: <tenant>
   gateway: https://observatorium-mst.api.stage.openshift.com
   authType: redhat  
   redHatSsoAuthServerUrl: https://sso.redhat.com/auth/

--- a/controllers/reconcilers/configuration/token_refresher.go
+++ b/controllers/reconcilers/configuration/token_refresher.go
@@ -365,7 +365,7 @@ func (r *Reconciler) deleteUnrequestedTokenRefreshers(ctx context.Context, cr *v
 		if oauth2Secret != nil {
 			return false
 		}
-		
+
 		for _, index := range indexes {
 			if index.Config == nil {
 				return false

--- a/controllers/reconcilers/token/token_manager.go
+++ b/controllers/reconcilers/token/token_manager.go
@@ -3,6 +3,8 @@ package token
 import (
 	"context"
 	"fmt"
+	"strconv"
+
 	"github.com/go-logr/logr"
 	errors2 "github.com/pkg/errors"
 	v1 "github.com/redhat-developer/observability-operator/v4/api/v1"
@@ -13,7 +15,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"strconv"
 )
 
 const (


### PR DESCRIPTION
This change removes requirement for observatorium config to contain a value for `tenant`.