### PR TITLE
collect logs for ingress and observability namespaces and group by logtype

### DIFF
--- a/controllers/reconcilers/logging_installation/logging_installation_reconciler.go
+++ b/controllers/reconcilers/logging_installation/logging_installation_reconciler.go
@@ -357,8 +357,10 @@ func (r *Reconciler) createClusterLogForwarderCr(ctx context.Context, cr *v1.Obs
 			clusterLogForwarder.Spec.Inputs = []v14.InputSpec{
 				{
 					Name: "kafka-operator-application-logs",
-					Application: &v14.Application{Namespaces: []string{"redhat-kas-fleetshard-operator", "redhat-managed-kafka-operator",
-						"redhat-kas-fleetshard-operator-qe", "redhat-managed-kafka-operator-qe"}},
+					Application: &v14.Application{Namespaces: []string{"redhat-kas-fleetshard-operator",
+						"redhat-managed-kafka-operator", "redhat-kas-fleetshard-operator-qe",
+						"redhat-managed-kafka-operator-qe", "openshift-logging",
+						"managed-application-services-observability"}},
 					Infrastructure: nil,
 					Audit:          nil,
 				},
@@ -371,7 +373,7 @@ func (r *Reconciler) createClusterLogForwarderCr(ctx context.Context, cr *v1.Obs
 					OutputTypeSpec: v14.OutputTypeSpec{
 						Cloudwatch: &v14.Cloudwatch{
 							Region:  "eu-west-1",
-							GroupBy: "namespaceName",
+							GroupBy: "logType",
 						},
 					},
 					TLS: &v14.OutputTLSSpec{},


### PR DESCRIPTION
- Collect logs for ingress namespace
- - We have a custom ingress so we should collect logs for it
- Collect logs for observability namespace
- - A namespace we manage so we should collect the logs
- Group by logType
- - This will make precreation of resources much more straightforward 

_Verification_

1. Deploy this to an OSD cluster.
2. Verify the new namespaces are in the clusterLogForwarder resource
3. Verify the GroupBy var in the ClusterlogForwarder is `logType`
